### PR TITLE
fix(python): checkpoint for eval command crashes on absolute paths

### DIFF
--- a/Resources/python/schola/scripts/rllib/eval/eval.py
+++ b/Resources/python/schola/scripts/rllib/eval/eval.py
@@ -72,7 +72,7 @@ def main(args: RllibEvalScriptSettings) -> Dict[str, Any]:
             )
 
     try:
-        algo = Algorithm.from_checkpoint(str(args.checkpoint))
+        algo = Algorithm.from_checkpoint(str(args.checkpoint.resolve()))
         _apply_eval_episode_budget(algo, args.n_eval_episodes)
         logger.info(
             "Running RLlib Algorithm.evaluate() for up to %d episodes (if supported by checkpoint config).",


### PR DESCRIPTION
## Summary

This PR fixes an issue where relative checkpoint paths supplied to `schola rllib eval` cause an issue with `Algorithm.from_checkpoint` which expects absolute paths only. 

## Type of change

- [x] Bug fix

## Changes

Paths are now resolved before being passed to `Algorithm.from_checkpoint`, which expects an absolute path.


## Testing

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`
- [ ] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
