### PR TITLE
fix(rllib): set train_batch_size_per_learner instead of train_batch_size

### DIFF
--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -334,7 +334,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
             lr=args.training_settings.learning_rate,
             gamma=args.training_settings.gamma,
             num_epochs=args.training_settings.num_epochs,
-            train_batch_size=args.training_settings.train_batch_size_per_learner,
+            train_batch_size_per_learner=args.training_settings.train_batch_size_per_learner,
             minibatch_size=args.training_settings.minibatch_size,
             **args.algorithm_settings.get_settings_dict(),
         )


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->
Update rllib's train script from using train_batch_size to train_batch_size_per_learner

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Bug fix

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
Update rllib's train script from using train_batch_size to train_batch_size_per_learner

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
