### PR TITLE
feat: add support for text spaces

### DIFF
--- a/Docs/Sphinx/guides/setting_up_inference.rst
+++ b/Docs/Sphinx/guides/setting_up_inference.rst
@@ -8,6 +8,12 @@ This guide will explain how to use your trained RL agents in inference mode (i.e
     
     This guide assumes you have already done a training run using Schola and have either a saved checkpoint or a model exported to Onnx.
 
+.. note::
+
+    Text spaces are not yet supported for NNE inference. The supported observation and action
+    spaces are Box, Discrete, MultiDiscrete, MultiBinary, and Dict (including nested combinations
+    of these).
+
 
 Convert a Checkpoint to Onnx
 ----------------------------

--- a/Proto/Points.proto
+++ b/Proto/Points.proto
@@ -27,6 +27,10 @@ message DictPoint {
     map<string, Point> values = 1;
 }
 
+message TextPoint {
+    string value = 1;
+}
+
 message Point {
     oneof point {
         BoxPoint box_point = 1;
@@ -34,6 +38,7 @@ message Point {
         MultiDiscretePoint multi_discrete_point = 3;
         MultiBinaryPoint multi_binary_point = 4;
         DictPoint dict_point = 5;
+        TextPoint text_point = 6;
     }
 }
 

--- a/Proto/Spaces.proto
+++ b/Proto/Spaces.proto
@@ -30,8 +30,8 @@ message MultiBinarySpace {
 
 message TextSpace {
     int32 max_length = 1;
-    optional int32 min_length = 2;
-    optional string charset = 3;
+    int32 min_length = 2;
+    string charset = 3;
 }
 
 message Space {

--- a/Proto/Spaces.proto
+++ b/Proto/Spaces.proto
@@ -28,6 +28,12 @@ message MultiBinarySpace {
     int32 shape = 1;
 }
 
+message TextSpace {
+    int32 max_length = 1;
+    optional int32 min_length = 2;
+    optional string charset = 3;
+}
+
 message Space {
     oneof space {
         BoxSpace box_space = 1;
@@ -35,6 +41,7 @@ message Space {
         MultiDiscreteSpace multi_discrete_space = 3;
         MultiBinarySpace multi_binary_space = 4;
         DictSpace dict_space = 5;
+        TextSpace text_space = 6;
     }
 }
 

--- a/Resources/python/schola/core/protocols/protobuf/deserialize.py
+++ b/Resources/python/schola/core/protocols/protobuf/deserialize.py
@@ -128,15 +128,11 @@ def _(msg: proto_spaces.MultiDiscreteSpace) -> spaces.MultiDiscrete:
 
 @from_proto.register
 def _(msg: proto_spaces.TextSpace) -> spaces.Text:
-    # min_length and charset use proto3 explicit presence; only forward them
-    # when set so Gymnasium's own defaults (min_length=1, alphanumeric charset)
-    # apply otherwise.
-    kwargs = {"max_length": msg.max_length}
-    if msg.HasField("min_length"):
-        kwargs["min_length"] = msg.min_length
-    if msg.HasField("charset"):
-        kwargs["charset"] = msg.charset
-    return spaces.Text(**kwargs)
+    return spaces.Text(
+        max_length=msg.max_length,
+        min_length=msg.min_length,
+        charset=msg.charset,
+    )
 
 
 @from_proto.register

--- a/Resources/python/schola/core/protocols/protobuf/deserialize.py
+++ b/Resources/python/schola/core/protocols/protobuf/deserialize.py
@@ -127,6 +127,19 @@ def _(msg: proto_spaces.MultiDiscreteSpace) -> spaces.MultiDiscrete:
 
 
 @from_proto.register
+def _(msg: proto_spaces.TextSpace) -> spaces.Text:
+    # min_length and charset use proto3 explicit presence; only forward them
+    # when set so Gymnasium's own defaults (min_length=1, alphanumeric charset)
+    # apply otherwise.
+    kwargs = {"max_length": msg.max_length}
+    if msg.HasField("min_length"):
+        kwargs["min_length"] = msg.min_length
+    if msg.HasField("charset"):
+        kwargs["charset"] = msg.charset
+    return spaces.Text(**kwargs)
+
+
+@from_proto.register
 def _(msg: proto_spaces.DictSpace) -> spaces.Dict:
     space_dict = {key: from_proto(value) for key, value in msg.spaces.items()}
     return spaces.Dict(spaces=space_dict)
@@ -165,6 +178,11 @@ def _(msg: proto_points.DiscretePoint) -> int:
 def _(msg: proto_points.MultiBinaryPoint) -> np.ndarray:
     # np.bool was removed in NumPy 1.24; use bool/np.bool_ for compatibility
     return np.array(msg.values, dtype=np.bool_)
+
+
+@from_proto.register
+def _(msg: proto_points.TextPoint) -> str:
+    return msg.value
 
 
 @from_proto.register

--- a/Resources/python/schola/core/protocols/protobuf/serialize.py
+++ b/Resources/python/schola/core/protocols/protobuf/serialize.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List
 import numpy as np
 
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, MultiBinary
-from gymnasium.spaces.text import alphanumeric
 import schola.generated.Spaces_pb2 as proto_spaces
 import schola.generated.Points_pb2 as proto_points
 import schola.generated.State_pb2 as state
@@ -211,15 +210,12 @@ def _(space: Discrete) -> proto_spaces.DiscreteSpace:
 
 @space_to_proto.register
 def _(space: spaces.Text) -> proto_spaces.TextSpace:
-    # min_length and charset use proto3 explicit presence. Only set them when
-    # they differ from Gymnasium's defaults so the deserializer can leave them
-    # unset and let Gymnasium apply its own defaults on the other side.
-    msg = proto_spaces.TextSpace(max_length=space.max_length)
-    if space.min_length != 1:
-        msg.min_length = space.min_length
-    if space.character_set != alphanumeric:
-        msg.charset = "".join(sorted(space.character_set))
-    return msg
+    # sorted string of the space's character_set, which may be empty (the empty set).
+    return proto_spaces.TextSpace(
+        max_length=space.max_length,
+        min_length=space.min_length,
+        charset="".join(sorted(space.character_set)),
+    )
 
 
 @space_to_proto.register

--- a/Resources/python/schola/core/protocols/protobuf/serialize.py
+++ b/Resources/python/schola/core/protocols/protobuf/serialize.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 import numpy as np
 
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, MultiBinary
+from gymnasium.spaces.text import alphanumeric
 import schola.generated.Spaces_pb2 as proto_spaces
 import schola.generated.Points_pb2 as proto_points
 import schola.generated.State_pb2 as state
@@ -210,9 +211,14 @@ def _(space: Discrete) -> proto_spaces.DiscreteSpace:
 
 @space_to_proto.register
 def _(space: spaces.Text) -> proto_spaces.TextSpace:
+    # min_length and charset use proto3 explicit presence. Only set them when
+    # they differ from Gymnasium's defaults so the deserializer can leave them
+    # unset and let Gymnasium apply its own defaults on the other side.
     msg = proto_spaces.TextSpace(max_length=space.max_length)
-    msg.min_length = space.min_length
-    msg.charset = "".join(sorted(space.character_set))
+    if space.min_length != 1:
+        msg.min_length = space.min_length
+    if space.character_set != alphanumeric:
+        msg.charset = "".join(sorted(space.character_set))
     return msg
 
 

--- a/Resources/python/schola/core/protocols/protobuf/serialize.py
+++ b/Resources/python/schola/core/protocols/protobuf/serialize.py
@@ -138,6 +138,12 @@ def _(space: spaces.Discrete, action: int) -> proto_points.DiscretePoint:
     return msg
 
 
+@to_proto.register
+def _(space: spaces.Text, action: str) -> proto_points.TextPoint:
+    msg = proto_points.TextPoint(value=action)
+    return msg
+
+
 @singledispatch
 def space_to_proto(space):
     """
@@ -199,6 +205,14 @@ def _(space: MultiDiscrete) -> proto_spaces.MultiDiscreteSpace:
 @space_to_proto.register
 def _(space: Discrete) -> proto_spaces.DiscreteSpace:
     msg = proto_spaces.DiscreteSpace(high=space.n)
+    return msg
+
+
+@space_to_proto.register
+def _(space: spaces.Text) -> proto_spaces.TextSpace:
+    msg = proto_spaces.TextSpace(max_length=space.max_length)
+    msg.min_length = space.min_length
+    msg.charset = "".join(sorted(space.character_set))
     return msg
 
 
@@ -270,11 +284,21 @@ def _(space: proto_spaces.MultiBinarySpace, generic_space: proto_spaces.Space) -
 
 
 @fill_generic.register
+def _(space: proto_spaces.TextSpace, generic_space: proto_spaces.Space) -> None:
+    generic_space.text_space.CopyFrom(space)
+
+
+@fill_generic.register
 def _(space: proto_spaces.DictSpace, generic_space: proto_spaces.Space) -> None:
     generic_space.dict_space.CopyFrom(space)
 
 
 # points
+
+
+@fill_generic.register
+def _(point: proto_points.TextPoint, generic_point: proto_points.Point) -> None:
+    generic_point.text_point.CopyFrom(point)
 
 
 @fill_generic.register
@@ -348,6 +372,12 @@ def _(space: proto_spaces.DictSpace) -> proto_spaces.Space:
 
 
 @make_generic.register
+def _(space: proto_spaces.TextSpace) -> proto_spaces.Space:
+    msg = proto_spaces.Space(text_space=space)
+    return msg
+
+
+@make_generic.register
 def _(space: proto_spaces.BoxSpace) -> proto_spaces.Space:
     msg = proto_spaces.Space(box_space=space)
     return msg
@@ -398,4 +428,10 @@ def _(point: proto_points.DiscretePoint) -> proto_points.Point:
 @make_generic.register
 def _(point: proto_points.MultiDiscretePoint) -> proto_points.Point:
     msg = proto_points.Point(multi_discrete_point=point)
+    return msg
+
+
+@make_generic.register
+def _(point: proto_points.TextPoint) -> proto_points.Point:
+    msg = proto_points.Point(text_point=point)
     return msg

--- a/Resources/python/schola/generated/Points_pb2.py
+++ b/Resources/python/schola/generated/Points_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 import schola.generated.DType_pb2 as DType__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cPoints.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"G\n\x08\x42oxPoint\x12\x0e\n\x06values\x18\x01 \x03(\x02\x12\x1c\n\x05\x64type\x18\x02 \x01(\x0e\x32\r.Schola.DType\x12\r\n\x05shape\x18\x03 \x03(\x05\"\x1e\n\rDiscretePoint\x12\r\n\x05value\x18\x01 \x01(\x05\"$\n\x12MultiDiscretePoint\x12\x0e\n\x06values\x18\x01 \x03(\x05\"\"\n\x10MultiBinaryPoint\x12\x0e\n\x06values\x18\x01 \x03(\x08\"x\n\tDictPoint\x12-\n\x06values\x18\x01 \x03(\x0b\x32\x1d.Schola.DictPoint.ValuesEntry\x1a<\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Point:\x02\x38\x01\"\x85\x02\n\x05Point\x12%\n\tbox_point\x18\x01 \x01(\x0b\x32\x10.Schola.BoxPointH\x00\x12/\n\x0e\x64iscrete_point\x18\x02 \x01(\x0b\x32\x15.Schola.DiscretePointH\x00\x12:\n\x14multi_discrete_point\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscretePointH\x00\x12\x36\n\x12multi_binary_point\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinaryPointH\x00\x12\'\n\ndict_point\x18\x05 \x01(\x0b\x32\x11.Schola.DictPointH\x00\x42\x07\n\x05pointb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cPoints.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"G\n\x08\x42oxPoint\x12\x0e\n\x06values\x18\x01 \x03(\x02\x12\x1c\n\x05\x64type\x18\x02 \x01(\x0e\x32\r.Schola.DType\x12\r\n\x05shape\x18\x03 \x03(\x05\"\x1e\n\rDiscretePoint\x12\r\n\x05value\x18\x01 \x01(\x05\"$\n\x12MultiDiscretePoint\x12\x0e\n\x06values\x18\x01 \x03(\x05\"\"\n\x10MultiBinaryPoint\x12\x0e\n\x06values\x18\x01 \x03(\x08\"x\n\tDictPoint\x12-\n\x06values\x18\x01 \x03(\x0b\x32\x1d.Schola.DictPoint.ValuesEntry\x1a<\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Point:\x02\x38\x01\"\x1a\n\tTextPoint\x12\r\n\x05value\x18\x01 \x01(\t\"\xae\x02\n\x05Point\x12%\n\tbox_point\x18\x01 \x01(\x0b\x32\x10.Schola.BoxPointH\x00\x12/\n\x0e\x64iscrete_point\x18\x02 \x01(\x0b\x32\x15.Schola.DiscretePointH\x00\x12:\n\x14multi_discrete_point\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscretePointH\x00\x12\x36\n\x12multi_binary_point\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinaryPointH\x00\x12\'\n\ndict_point\x18\x05 \x01(\x0b\x32\x11.Schola.DictPointH\x00\x12\'\n\ntext_point\x18\x06 \x01(\x0b\x32\x11.Schola.TextPointH\x00\x42\x07\n\x05pointb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -46,6 +46,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_DICTPOINT']._serialized_end=336
   _globals['_DICTPOINT_VALUESENTRY']._serialized_start=276
   _globals['_DICTPOINT_VALUESENTRY']._serialized_end=336
-  _globals['_POINT']._serialized_start=339
-  _globals['_POINT']._serialized_end=600
+  _globals['_TEXTPOINT']._serialized_start=338
+  _globals['_TEXTPOINT']._serialized_end=364
+  _globals['_POINT']._serialized_start=367
+  _globals['_POINT']._serialized_end=669
 # @@protoc_insertion_point(module_scope)

--- a/Resources/python/schola/generated/Points_pb2.pyi
+++ b/Resources/python/schola/generated/Points_pb2.pyi
@@ -48,16 +48,24 @@ class DictPoint(_message.Message):
     values: _containers.MessageMap[str, Point]
     def __init__(self, values: _Optional[_Mapping[str, Point]] = ...) -> None: ...
 
+class TextPoint(_message.Message):
+    __slots__ = ("value",)
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    value: str
+    def __init__(self, value: _Optional[str] = ...) -> None: ...
+
 class Point(_message.Message):
-    __slots__ = ("box_point", "discrete_point", "multi_discrete_point", "multi_binary_point", "dict_point")
+    __slots__ = ("box_point", "discrete_point", "multi_discrete_point", "multi_binary_point", "dict_point", "text_point")
     BOX_POINT_FIELD_NUMBER: _ClassVar[int]
     DISCRETE_POINT_FIELD_NUMBER: _ClassVar[int]
     MULTI_DISCRETE_POINT_FIELD_NUMBER: _ClassVar[int]
     MULTI_BINARY_POINT_FIELD_NUMBER: _ClassVar[int]
     DICT_POINT_FIELD_NUMBER: _ClassVar[int]
+    TEXT_POINT_FIELD_NUMBER: _ClassVar[int]
     box_point: BoxPoint
     discrete_point: DiscretePoint
     multi_discrete_point: MultiDiscretePoint
     multi_binary_point: MultiBinaryPoint
     dict_point: DictPoint
-    def __init__(self, box_point: _Optional[_Union[BoxPoint, _Mapping]] = ..., discrete_point: _Optional[_Union[DiscretePoint, _Mapping]] = ..., multi_discrete_point: _Optional[_Union[MultiDiscretePoint, _Mapping]] = ..., multi_binary_point: _Optional[_Union[MultiBinaryPoint, _Mapping]] = ..., dict_point: _Optional[_Union[DictPoint, _Mapping]] = ...) -> None: ...
+    text_point: TextPoint
+    def __init__(self, box_point: _Optional[_Union[BoxPoint, _Mapping]] = ..., discrete_point: _Optional[_Union[DiscretePoint, _Mapping]] = ..., multi_discrete_point: _Optional[_Union[MultiDiscretePoint, _Mapping]] = ..., multi_binary_point: _Optional[_Union[MultiBinaryPoint, _Mapping]] = ..., dict_point: _Optional[_Union[DictPoint, _Mapping]] = ..., text_point: _Optional[_Union[TextPoint, _Mapping]] = ...) -> None: ...

--- a/Resources/python/schola/generated/Spaces_pb2.py
+++ b/Resources/python/schola/generated/Spaces_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 import schola.generated.DType_pb2 as DType__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cSpaces.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"\xaa\x01\n\x08\x42oxSpace\x12\x36\n\ndimensions\x18\x01 \x03(\x0b\x32\".Schola.BoxSpace.BoxSpaceDimension\x12\x18\n\x10shape_dimensions\x18\x02 \x03(\x05\x12\x1c\n\x05\x64type\x18\x03 \x01(\x0e\x32\r.Schola.DType\x1a.\n\x11\x42oxSpaceDimension\x12\x0b\n\x03low\x18\x01 \x01(\x02\x12\x0c\n\x04high\x18\x02 \x01(\x02\"\x1d\n\rDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x01(\x05\"\"\n\x12MultiDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x03(\x05\"!\n\x10MultiBinarySpace\x12\r\n\x05shape\x18\x01 \x01(\x05\"i\n\tTextSpace\x12\x12\n\nmax_length\x18\x01 \x01(\x05\x12\x17\n\nmin_length\x18\x02 \x01(\x05H\x00\x88\x01\x01\x12\x14\n\x07\x63harset\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_min_lengthB\n\n\x08_charset\"\xae\x02\n\x05Space\x12%\n\tbox_space\x18\x01 \x01(\x0b\x32\x10.Schola.BoxSpaceH\x00\x12/\n\x0e\x64iscrete_space\x18\x02 \x01(\x0b\x32\x15.Schola.DiscreteSpaceH\x00\x12:\n\x14multi_discrete_space\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscreteSpaceH\x00\x12\x36\n\x12multi_binary_space\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinarySpaceH\x00\x12\'\n\ndict_space\x18\x05 \x01(\x0b\x32\x11.Schola.DictSpaceH\x00\x12\'\n\ntext_space\x18\x06 \x01(\x0b\x32\x11.Schola.TextSpaceH\x00\x42\x07\n\x05space\"x\n\tDictSpace\x12-\n\x06spaces\x18\x01 \x03(\x0b\x32\x1d.Schola.DictSpace.SpacesEntry\x1a<\n\x0bSpacesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Space:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cSpaces.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"\xaa\x01\n\x08\x42oxSpace\x12\x36\n\ndimensions\x18\x01 \x03(\x0b\x32\".Schola.BoxSpace.BoxSpaceDimension\x12\x18\n\x10shape_dimensions\x18\x02 \x03(\x05\x12\x1c\n\x05\x64type\x18\x03 \x01(\x0e\x32\r.Schola.DType\x1a.\n\x11\x42oxSpaceDimension\x12\x0b\n\x03low\x18\x01 \x01(\x02\x12\x0c\n\x04high\x18\x02 \x01(\x02\"\x1d\n\rDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x01(\x05\"\"\n\x12MultiDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x03(\x05\"!\n\x10MultiBinarySpace\x12\r\n\x05shape\x18\x01 \x01(\x05\"D\n\tTextSpace\x12\x12\n\nmax_length\x18\x01 \x01(\x05\x12\x12\n\nmin_length\x18\x02 \x01(\x05\x12\x0f\n\x07\x63harset\x18\x03 \x01(\t\"\xae\x02\n\x05Space\x12%\n\tbox_space\x18\x01 \x01(\x0b\x32\x10.Schola.BoxSpaceH\x00\x12/\n\x0e\x64iscrete_space\x18\x02 \x01(\x0b\x32\x15.Schola.DiscreteSpaceH\x00\x12:\n\x14multi_discrete_space\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscreteSpaceH\x00\x12\x36\n\x12multi_binary_space\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinarySpaceH\x00\x12\'\n\ndict_space\x18\x05 \x01(\x0b\x32\x11.Schola.DictSpaceH\x00\x12\'\n\ntext_space\x18\x06 \x01(\x0b\x32\x11.Schola.TextSpaceH\x00\x42\x07\n\x05space\"x\n\tDictSpace\x12-\n\x06spaces\x18\x01 \x03(\x0b\x32\x1d.Schola.DictSpace.SpacesEntry\x1a<\n\x0bSpacesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Space:\x02\x38\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -45,11 +45,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_MULTIBINARYSPACE']._serialized_start=277
   _globals['_MULTIBINARYSPACE']._serialized_end=310
   _globals['_TEXTSPACE']._serialized_start=312
-  _globals['_TEXTSPACE']._serialized_end=417
-  _globals['_SPACE']._serialized_start=420
-  _globals['_SPACE']._serialized_end=722
-  _globals['_DICTSPACE']._serialized_start=724
-  _globals['_DICTSPACE']._serialized_end=844
-  _globals['_DICTSPACE_SPACESENTRY']._serialized_start=784
-  _globals['_DICTSPACE_SPACESENTRY']._serialized_end=844
+  _globals['_TEXTSPACE']._serialized_end=380
+  _globals['_SPACE']._serialized_start=383
+  _globals['_SPACE']._serialized_end=685
+  _globals['_DICTSPACE']._serialized_start=687
+  _globals['_DICTSPACE']._serialized_end=807
+  _globals['_DICTSPACE_SPACESENTRY']._serialized_start=747
+  _globals['_DICTSPACE_SPACESENTRY']._serialized_end=807
 # @@protoc_insertion_point(module_scope)

--- a/Resources/python/schola/generated/Spaces_pb2.py
+++ b/Resources/python/schola/generated/Spaces_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 import schola.generated.DType_pb2 as DType__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cSpaces.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"\xaa\x01\n\x08\x42oxSpace\x12\x36\n\ndimensions\x18\x01 \x03(\x0b\x32\".Schola.BoxSpace.BoxSpaceDimension\x12\x18\n\x10shape_dimensions\x18\x02 \x03(\x05\x12\x1c\n\x05\x64type\x18\x03 \x01(\x0e\x32\r.Schola.DType\x1a.\n\x11\x42oxSpaceDimension\x12\x0b\n\x03low\x18\x01 \x01(\x02\x12\x0c\n\x04high\x18\x02 \x01(\x02\"\x1d\n\rDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x01(\x05\"\"\n\x12MultiDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x03(\x05\"!\n\x10MultiBinarySpace\x12\r\n\x05shape\x18\x01 \x01(\x05\"\x85\x02\n\x05Space\x12%\n\tbox_space\x18\x01 \x01(\x0b\x32\x10.Schola.BoxSpaceH\x00\x12/\n\x0e\x64iscrete_space\x18\x02 \x01(\x0b\x32\x15.Schola.DiscreteSpaceH\x00\x12:\n\x14multi_discrete_space\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscreteSpaceH\x00\x12\x36\n\x12multi_binary_space\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinarySpaceH\x00\x12\'\n\ndict_space\x18\x05 \x01(\x0b\x32\x11.Schola.DictSpaceH\x00\x42\x07\n\x05space\"x\n\tDictSpace\x12-\n\x06spaces\x18\x01 \x03(\x0b\x32\x1d.Schola.DictSpace.SpacesEntry\x1a<\n\x0bSpacesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Space:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cSpaces.proto\x12\x06Schola\x1a\x0b\x44Type.proto\"\xaa\x01\n\x08\x42oxSpace\x12\x36\n\ndimensions\x18\x01 \x03(\x0b\x32\".Schola.BoxSpace.BoxSpaceDimension\x12\x18\n\x10shape_dimensions\x18\x02 \x03(\x05\x12\x1c\n\x05\x64type\x18\x03 \x01(\x0e\x32\r.Schola.DType\x1a.\n\x11\x42oxSpaceDimension\x12\x0b\n\x03low\x18\x01 \x01(\x02\x12\x0c\n\x04high\x18\x02 \x01(\x02\"\x1d\n\rDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x01(\x05\"\"\n\x12MultiDiscreteSpace\x12\x0c\n\x04high\x18\x01 \x03(\x05\"!\n\x10MultiBinarySpace\x12\r\n\x05shape\x18\x01 \x01(\x05\"i\n\tTextSpace\x12\x12\n\nmax_length\x18\x01 \x01(\x05\x12\x17\n\nmin_length\x18\x02 \x01(\x05H\x00\x88\x01\x01\x12\x14\n\x07\x63harset\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_min_lengthB\n\n\x08_charset\"\xae\x02\n\x05Space\x12%\n\tbox_space\x18\x01 \x01(\x0b\x32\x10.Schola.BoxSpaceH\x00\x12/\n\x0e\x64iscrete_space\x18\x02 \x01(\x0b\x32\x15.Schola.DiscreteSpaceH\x00\x12:\n\x14multi_discrete_space\x18\x03 \x01(\x0b\x32\x1a.Schola.MultiDiscreteSpaceH\x00\x12\x36\n\x12multi_binary_space\x18\x04 \x01(\x0b\x32\x18.Schola.MultiBinarySpaceH\x00\x12\'\n\ndict_space\x18\x05 \x01(\x0b\x32\x11.Schola.DictSpaceH\x00\x12\'\n\ntext_space\x18\x06 \x01(\x0b\x32\x11.Schola.TextSpaceH\x00\x42\x07\n\x05space\"x\n\tDictSpace\x12-\n\x06spaces\x18\x01 \x03(\x0b\x32\x1d.Schola.DictSpace.SpacesEntry\x1a<\n\x0bSpacesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x05value\x18\x02 \x01(\x0b\x32\r.Schola.Space:\x02\x38\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -44,10 +44,12 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_MULTIDISCRETESPACE']._serialized_end=275
   _globals['_MULTIBINARYSPACE']._serialized_start=277
   _globals['_MULTIBINARYSPACE']._serialized_end=310
-  _globals['_SPACE']._serialized_start=313
-  _globals['_SPACE']._serialized_end=574
-  _globals['_DICTSPACE']._serialized_start=576
-  _globals['_DICTSPACE']._serialized_end=696
-  _globals['_DICTSPACE_SPACESENTRY']._serialized_start=636
-  _globals['_DICTSPACE_SPACESENTRY']._serialized_end=696
+  _globals['_TEXTSPACE']._serialized_start=312
+  _globals['_TEXTSPACE']._serialized_end=417
+  _globals['_SPACE']._serialized_start=420
+  _globals['_SPACE']._serialized_end=722
+  _globals['_DICTSPACE']._serialized_start=724
+  _globals['_DICTSPACE']._serialized_end=844
+  _globals['_DICTSPACE_SPACESENTRY']._serialized_start=784
+  _globals['_DICTSPACE_SPACESENTRY']._serialized_end=844
 # @@protoc_insertion_point(module_scope)

--- a/Resources/python/schola/generated/Spaces_pb2.pyi
+++ b/Resources/python/schola/generated/Spaces_pb2.pyi
@@ -42,19 +42,31 @@ class MultiBinarySpace(_message.Message):
     shape: int
     def __init__(self, shape: _Optional[int] = ...) -> None: ...
 
+class TextSpace(_message.Message):
+    __slots__ = ("max_length", "min_length", "charset")
+    MAX_LENGTH_FIELD_NUMBER: _ClassVar[int]
+    MIN_LENGTH_FIELD_NUMBER: _ClassVar[int]
+    CHARSET_FIELD_NUMBER: _ClassVar[int]
+    max_length: int
+    min_length: int
+    charset: str
+    def __init__(self, max_length: _Optional[int] = ..., min_length: _Optional[int] = ..., charset: _Optional[str] = ...) -> None: ...
+
 class Space(_message.Message):
-    __slots__ = ("box_space", "discrete_space", "multi_discrete_space", "multi_binary_space", "dict_space")
+    __slots__ = ("box_space", "discrete_space", "multi_discrete_space", "multi_binary_space", "dict_space", "text_space")
     BOX_SPACE_FIELD_NUMBER: _ClassVar[int]
     DISCRETE_SPACE_FIELD_NUMBER: _ClassVar[int]
     MULTI_DISCRETE_SPACE_FIELD_NUMBER: _ClassVar[int]
     MULTI_BINARY_SPACE_FIELD_NUMBER: _ClassVar[int]
     DICT_SPACE_FIELD_NUMBER: _ClassVar[int]
+    TEXT_SPACE_FIELD_NUMBER: _ClassVar[int]
     box_space: BoxSpace
     discrete_space: DiscreteSpace
     multi_discrete_space: MultiDiscreteSpace
     multi_binary_space: MultiBinarySpace
     dict_space: DictSpace
-    def __init__(self, box_space: _Optional[_Union[BoxSpace, _Mapping]] = ..., discrete_space: _Optional[_Union[DiscreteSpace, _Mapping]] = ..., multi_discrete_space: _Optional[_Union[MultiDiscreteSpace, _Mapping]] = ..., multi_binary_space: _Optional[_Union[MultiBinarySpace, _Mapping]] = ..., dict_space: _Optional[_Union[DictSpace, _Mapping]] = ...) -> None: ...
+    text_space: TextSpace
+    def __init__(self, box_space: _Optional[_Union[BoxSpace, _Mapping]] = ..., discrete_space: _Optional[_Union[DiscreteSpace, _Mapping]] = ..., multi_discrete_space: _Optional[_Union[MultiDiscreteSpace, _Mapping]] = ..., multi_binary_space: _Optional[_Union[MultiBinarySpace, _Mapping]] = ..., dict_space: _Optional[_Union[DictSpace, _Mapping]] = ..., text_space: _Optional[_Union[TextSpace, _Mapping]] = ...) -> None: ...
 
 class DictSpace(_message.Message):
     __slots__ = ("spaces",)

--- a/Source/Schola/Private/Points/Blueprint/PointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/PointBlueprintLibrary.cpp
@@ -7,6 +7,7 @@
 #include "Points/BoxPoint.h"
 #include "Points/DictPoint.h"
 #include "Points/MultiDiscretePoint.h"
+#include "Points/TextPoint.h"
 
 EPointType UPointBlueprintLibrary::Point_Type(const FInstancedStruct& InPoint)
 {
@@ -33,6 +34,11 @@ EPointType UPointBlueprintLibrary::Point_Type(const FInstancedStruct& InPoint)
 	if (InPoint.GetScriptStruct() && InPoint.GetScriptStruct()->IsChildOf(FDictPoint::StaticStruct()))
 	{
 		return EPointType::Dict;
+	}
+
+    if (InPoint.GetScriptStruct() && InPoint.GetScriptStruct()->IsChildOf(FTextPoint::StaticStruct()))
+	{
+		return EPointType::Text;
 	}
 
     return EPointType::MultiBinary;

--- a/Source/Schola/Private/Points/Blueprint/TextPointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/TextPointBlueprintLibrary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Points/Blueprint/TextPointBlueprintLibrary.h"
 #include "Points/TextPoint.h"

--- a/Source/Schola/Private/Points/Blueprint/TextPointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/TextPointBlueprintLibrary.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Points/Blueprint/TextPointBlueprintLibrary.h"
+#include "Points/TextPoint.h"
+#include "Common/BlueprintErrorUtils.h"
+
+TInstancedStruct<FTextPoint> UTextPointBlueprintLibrary::StringToTextPoint(const FString& InValue)
+{
+    return TInstancedStruct<FTextPoint>::Make(InValue);
+}
+
+FString UTextPointBlueprintLibrary::TextPointToString(const TInstancedStruct<FTextPoint>& InTextPoint)
+{
+    // Type check: ensure the InstancedStruct is actually a FTextPoint
+    if (!InTextPoint.IsValid())
+    {
+        RaiseInvalidInstancedStructError(TEXT("TextPointToString"));
+        return FString();
+    }
+
+    const FTextPoint* TypedPoint = InTextPoint.GetPtr<FTextPoint>();
+
+    if (!TypedPoint)
+    {
+        RaiseInstancedStructTypeMismatchError(InTextPoint, TEXT("FTextPoint"), TEXT("TextPointToString"));
+        return FString();
+    }
+
+    return TypedPoint->Value;
+}

--- a/Source/Schola/Private/Points/TextPoint.cpp
+++ b/Source/Schola/Private/Points/TextPoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Points/TextPoint.h"
 

--- a/Source/Schola/Private/Points/TextPoint.cpp
+++ b/Source/Schola/Private/Points/TextPoint.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Points/TextPoint.h"
+
+void FTextPoint::Accept(ConstPointVisitor& Visitor) const
+{
+	Visitor(*this);
+}
+
+void FTextPoint::Accept(PointVisitor& Visitor)
+{
+	Visitor(*this);
+}

--- a/Source/Schola/Private/Spaces/Blueprint/SpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/SpaceBlueprintLibrary.cpp
@@ -7,6 +7,7 @@
 #include "Spaces/BoxSpace.h"
 #include "Spaces/DictSpace.h"
 #include "Spaces/DiscreteSpace.h"
+#include "Spaces/TextSpace.h"
 #include "Common/BlueprintErrorUtils.h"
 #include "Common/InstancedStructUtils.h"
 
@@ -35,6 +36,11 @@ ESpaceType USpaceBlueprintLibrary::Space_Type(const FInstancedStruct& InSpace)
     if (InSpace.GetScriptStruct() && InSpace.GetScriptStruct()->IsChildOf(FDictSpace::StaticStruct()))
 	{
 		return ESpaceType::Dict;
+	}
+
+    if (InSpace.GetScriptStruct() && InSpace.GetScriptStruct()->IsChildOf(FTextSpace::StaticStruct()))
+	{
+		return ESpaceType::Text;
 	}
 
     return ESpaceType::MultiBinary;

--- a/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Spaces/Blueprint/TextSpaceBlueprintLibrary.h"
+#include "Spaces/TextSpace.h"
+#include "Common/BlueprintErrorUtils.h"
+
+TInstancedStruct<FTextSpace> UTextSpaceBlueprintLibrary::MakeTextSpace(int32 InMaxLength, bool bInHasMinLength, int32 InMinLength, const FString& InCharset)
+{
+    return TInstancedStruct<FTextSpace>::Make(InMaxLength, bInHasMinLength, InMinLength, InCharset);
+}
+
+void UTextSpaceBlueprintLibrary::BreakTextSpace(const TInstancedStruct<FTextSpace>& InTextSpace, int32& OutMaxLength, bool& bOutHasMinLength, int32& OutMinLength, FString& OutCharset)
+{
+    OutMaxLength = 0;
+    bOutHasMinLength = false;
+    OutMinLength = 0;
+    OutCharset = FString();
+
+    // Type check: ensure the InstancedStruct is actually a FTextSpace
+    if (!InTextSpace.IsValid())
+    {
+        RaiseInvalidInstancedStructError(TEXT("BreakTextSpace"));
+        return;
+    }
+
+    const FTextSpace* TypedSpace = InTextSpace.GetPtr<FTextSpace>();
+
+    if (!TypedSpace)
+    {
+        RaiseInstancedStructTypeMismatchError(InTextSpace, TEXT("FTextSpace"), TEXT("BreakTextSpace"));
+        return;
+    }
+
+    OutMaxLength = TypedSpace->MaxLength;
+    bOutHasMinLength = TypedSpace->bHasMinLength;
+    OutMinLength = TypedSpace->MinLength;
+    OutCharset = TypedSpace->Charset;
+}

--- a/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Spaces/Blueprint/TextSpaceBlueprintLibrary.h"
 #include "Spaces/TextSpace.h"

--- a/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
@@ -57,9 +57,7 @@ FString UTextSpaceBlueprintLibrary::GetTextCharsetPreset(ETextCharsetPreset InPr
     case ETextCharsetPreset::Alphabetic:
         return ScholaTextCharsets::Alphabetic;
     case ETextCharsetPreset::Alphanumeric:
-        return ScholaTextCharsets::Alphanumeric;
-    case ETextCharsetPreset::Any:
     default:
-        return ScholaTextCharsets::Any;
+        return ScholaTextCharsets::Alphanumeric;
     }
 }

--- a/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/TextSpaceBlueprintLibrary.cpp
@@ -4,16 +4,28 @@
 #include "Spaces/TextSpace.h"
 #include "Common/BlueprintErrorUtils.h"
 
-TInstancedStruct<FTextSpace> UTextSpaceBlueprintLibrary::MakeTextSpace(int32 InMaxLength, bool bInHasMinLength, int32 InMinLength, const FString& InCharset)
+TInstancedStruct<FTextSpace> UTextSpaceBlueprintLibrary::MakeTextSpace(int32 InMaxLength, int32 InMinLength, const FString& InCharset)
 {
-    return TInstancedStruct<FTextSpace>::Make(InMaxLength, bInHasMinLength, InMinLength, InCharset);
+    // A space with MinLength > MaxLength can never contain a valid string. Clamp and warn rather
+    // than producing an incoherent space. (UPARAM/clamp metadata can bound each value individually
+    // but cannot express the relational MinLength <= MaxLength constraint, so it is enforced here.)
+    if (InMinLength > InMaxLength)
+    {
+        RaiseBlueprintError(TEXT("MakeTextSpace"), FString::Printf(TEXT("Min Length (%d) cannot exceed Max Length (%d). Clamping Min Length to Max Length."), InMinLength, InMaxLength));
+        InMinLength = InMaxLength;
+    }
+    return TInstancedStruct<FTextSpace>::Make(InMaxLength, InMinLength, InCharset);
 }
 
-void UTextSpaceBlueprintLibrary::BreakTextSpace(const TInstancedStruct<FTextSpace>& InTextSpace, int32& OutMaxLength, bool& bOutHasMinLength, int32& OutMinLength, FString& OutCharset)
+TInstancedStruct<FTextSpace> UTextSpaceBlueprintLibrary::MakeTextSpaceFromPreset(int32 InMaxLength, int32 InMinLength, ETextCharsetPreset InCharsetPreset)
+{
+    return MakeTextSpace(InMaxLength, InMinLength, GetTextCharsetPreset(InCharsetPreset));
+}
+
+void UTextSpaceBlueprintLibrary::BreakTextSpace(const TInstancedStruct<FTextSpace>& InTextSpace, int32& OutMaxLength, int32& OutMinLength, FString& OutCharset)
 {
     OutMaxLength = 0;
-    bOutHasMinLength = false;
-    OutMinLength = 0;
+    OutMinLength = 1;
     OutCharset = FString();
 
     // Type check: ensure the InstancedStruct is actually a FTextSpace
@@ -32,7 +44,22 @@ void UTextSpaceBlueprintLibrary::BreakTextSpace(const TInstancedStruct<FTextSpac
     }
 
     OutMaxLength = TypedSpace->MaxLength;
-    bOutHasMinLength = TypedSpace->bHasMinLength;
     OutMinLength = TypedSpace->MinLength;
     OutCharset = TypedSpace->Charset;
+}
+
+FString UTextSpaceBlueprintLibrary::GetTextCharsetPreset(ETextCharsetPreset InPreset)
+{
+    switch (InPreset)
+    {
+    case ETextCharsetPreset::Numeric:
+        return ScholaTextCharsets::Numeric;
+    case ETextCharsetPreset::Alphabetic:
+        return ScholaTextCharsets::Alphabetic;
+    case ETextCharsetPreset::Alphanumeric:
+        return ScholaTextCharsets::Alphanumeric;
+    case ETextCharsetPreset::Any:
+    default:
+        return ScholaTextCharsets::Any;
+    }
 }

--- a/Source/Schola/Private/Spaces/TextSpace.cpp
+++ b/Source/Schola/Private/Spaces/TextSpace.cpp
@@ -2,8 +2,6 @@
 
 #include "Spaces/TextSpace.h"
 
-
-
 FTextSpace::FTextSpace()
 	: MaxLength(0)
 {
@@ -12,7 +10,6 @@ FTextSpace::FTextSpace()
 void FTextSpace::Copy(const FTextSpace& Other)
 {
 	this->MaxLength = Other.MaxLength;
-	this->bHasMinLength = Other.bHasMinLength;
 	this->MinLength = Other.MinLength;
 	this->Charset = Other.Charset;
 }
@@ -33,20 +30,24 @@ ESpaceValidationResult FTextSpace::Validate(const TInstancedStruct<FPoint>& InPo
 		return ESpaceValidationResult::OutOfBounds;
 	}
 
-	if (this->bHasMinLength && Length < this->MinLength)
+	if (Length < this->MinLength)
 	{
 		return ESpaceValidationResult::OutOfBounds;
 	}
 
-	if (!this->Charset.IsEmpty())
+	// An empty charset maps to Gymnasium's default (alphanumeric) set when the space
+	// is exchanged with Python, where "no restriction" cannot be represented. Validate
+	// against that same set so a point accepted here is also accepted across the boundary.
+	const FString EffectiveCharset = this->Charset.IsEmpty()
+		? FString(ScholaTextCharsets::Alphanumeric)
+		: this->Charset;
+
+	for (const TCHAR Character : TypedObservation->Value)
 	{
-		for (const TCHAR Character : TypedObservation->Value)
+		int32 Index = INDEX_NONE;
+		if (!EffectiveCharset.FindChar(Character, Index))
 		{
-			int32 Index = INDEX_NONE;
-			if (!this->Charset.FindChar(Character, Index))
-			{
-				return ESpaceValidationResult::OutOfBounds;
-			}
+			return ESpaceValidationResult::OutOfBounds;
 		}
 	}
 

--- a/Source/Schola/Private/Spaces/TextSpace.cpp
+++ b/Source/Schola/Private/Spaces/TextSpace.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Spaces/TextSpace.h"
+
+
+
+FTextSpace::FTextSpace()
+	: MaxLength(0)
+{
+}
+
+void FTextSpace::Copy(const FTextSpace& Other)
+{
+	this->MaxLength = Other.MaxLength;
+	this->bHasMinLength = Other.bHasMinLength;
+	this->MinLength = Other.MinLength;
+	this->Charset = Other.Charset;
+}
+
+
+ESpaceValidationResult FTextSpace::Validate(const TInstancedStruct<FPoint>& InPoint) const
+{
+
+	const FTextPoint* TypedObservation = InPoint.GetPtr<FTextPoint>();
+	if (!TypedObservation)
+	{
+		return ESpaceValidationResult::WrongDataType;
+	}
+
+	const int Length = TypedObservation->Value.Len();
+	if (Length > this->MaxLength)
+	{
+		return ESpaceValidationResult::OutOfBounds;
+	}
+
+	if (this->bHasMinLength && Length < this->MinLength)
+	{
+		return ESpaceValidationResult::OutOfBounds;
+	}
+
+	if (!this->Charset.IsEmpty())
+	{
+		for (const TCHAR Character : TypedObservation->Value)
+		{
+			int32 Index = INDEX_NONE;
+			if (!this->Charset.FindChar(Character, Index))
+			{
+				return ESpaceValidationResult::OutOfBounds;
+			}
+		}
+	}
+
+	return ESpaceValidationResult::Success;
+}
+
+int FTextSpace::GetNumDimensions() const
+{
+	return 1;
+}
+
+int FTextSpace::GetFlattenedSize() const
+{
+	return this->MaxLength;
+}
+
+bool FTextSpace::IsEmpty() const
+{
+	return this->MaxLength == 0;
+}

--- a/Source/Schola/Private/Spaces/TextSpace.cpp
+++ b/Source/Schola/Private/Spaces/TextSpace.cpp
@@ -35,17 +35,10 @@ ESpaceValidationResult FTextSpace::Validate(const TInstancedStruct<FPoint>& InPo
 		return ESpaceValidationResult::OutOfBounds;
 	}
 
-	// An empty charset maps to Gymnasium's default (alphanumeric) set when the space
-	// is exchanged with Python, where "no restriction" cannot be represented. Validate
-	// against that same set so a point accepted here is also accepted across the boundary.
-	const FString EffectiveCharset = this->Charset.IsEmpty()
-		? FString(ScholaTextCharsets::Alphanumeric)
-		: this->Charset;
-
 	for (const TCHAR Character : TypedObservation->Value)
 	{
 		int32 Index = INDEX_NONE;
-		if (!EffectiveCharset.FindChar(Character, Index))
+		if (!this->Charset.FindChar(Character, Index))
 		{
 			return ESpaceValidationResult::OutOfBounds;
 		}

--- a/Source/Schola/Private/Spaces/TextSpace.cpp
+++ b/Source/Schola/Private/Spaces/TextSpace.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Spaces/TextSpace.h"
 

--- a/Source/Schola/Private/Test/Points/Blueprint/PointBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Points/Blueprint/PointBlueprintLibraryTest.cpp
@@ -7,6 +7,7 @@
 #include "Points/MultiBinaryPoint.h"
 #include "Points/MultiDiscretePoint.h"
 #include "Points/DictPoint.h"
+#include "Points/TextPoint.h"
 #include "Common/InstancedStructUtils.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
@@ -86,6 +87,20 @@ bool FPointBlueprintLibrary_Type_DictTest::RunTest(const FString& Parameters)
     EPointType Result = UPointBlueprintLibrary::Point_Type(ToUntypedInstancedStruct(Point));
 
     TestEqual(TEXT("Point_Type(DictPoint) == EPointType::Dict"), Result, EPointType::Dict);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_Type_TextTest, "Schola.Points.Blueprint.PointBlueprintLibrary.Type.Text", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_Type_TextTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FTextPoint>(FString(TEXT("hello")));
+
+    EPointType Result = UPointBlueprintLibrary::Point_Type(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("Point_Type(TextPoint) == EPointType::Text"), Result, EPointType::Text);
 
     return true;
 }
@@ -172,6 +187,20 @@ bool FPointBlueprintLibrary_IsOfType_DictTrueTest::RunTest(const FString& Parame
     bool Result = UPointBlueprintLibrary::Point_IsOfType(ToUntypedInstancedStruct(Point), EPointType::Dict);
 
     TestTrue(TEXT("Point_IsOfType(DictPoint, Dict) == true"), Result);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_IsOfType_TextTrueTest, "Schola.Points.Blueprint.PointBlueprintLibrary.IsOfType.TextTrue", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_IsOfType_TextTrueTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FTextPoint>(FString(TEXT("hello")));
+
+    bool Result = UPointBlueprintLibrary::Point_IsOfType(ToUntypedInstancedStruct(Point), EPointType::Text);
+
+    TestTrue(TEXT("Point_IsOfType(TextPoint, Text) == true"), Result);
 
     return true;
 }

--- a/Source/Schola/Private/Test/Points/Blueprint/TextPointBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Points/Blueprint/TextPointBlueprintLibraryTest.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+#include "Points/Blueprint/TextPointBlueprintLibrary.h"
+#include "Points/TextPoint.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+// StringToTextPoint Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointBlueprintLibrary_StringToTextPoint_BasicTest, "Schola.Points.Blueprint.TextPointBlueprintLibrary.StringToTextPoint.Basic", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointBlueprintLibrary_StringToTextPoint_BasicTest::RunTest(const FString& Parameters)
+{
+    FString Value = TEXT("hello world");
+
+    TInstancedStruct<FTextPoint> Result = UTextPointBlueprintLibrary::StringToTextPoint(Value);
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextPoint& TextPoint = Result.Get<FTextPoint>();
+    TestEqual(TEXT("TextPoint.Value"), TextPoint.Value, Value);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointBlueprintLibrary_StringToTextPoint_EmptyTest, "Schola.Points.Blueprint.TextPointBlueprintLibrary.StringToTextPoint.Empty", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointBlueprintLibrary_StringToTextPoint_EmptyTest::RunTest(const FString& Parameters)
+{
+    FString Value;
+
+    TInstancedStruct<FTextPoint> Result = UTextPointBlueprintLibrary::StringToTextPoint(Value);
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextPoint& TextPoint = Result.Get<FTextPoint>();
+    TestTrue(TEXT("TextPoint.Value is empty"), TextPoint.Value.IsEmpty());
+
+    return true;
+}
+
+// TextPointToString Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointBlueprintLibrary_TextPointToString_BasicTest, "Schola.Points.Blueprint.TextPointBlueprintLibrary.TextPointToString.Basic", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointBlueprintLibrary_TextPointToString_BasicTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextPoint> Point;
+    Point.InitializeAs<FTextPoint>();
+    Point.GetMutable<FTextPoint>().Value = TEXT("sample text");
+
+    FString Result = UTextPointBlueprintLibrary::TextPointToString(Point);
+
+    TestEqual(TEXT("Result"), Result, FString(TEXT("sample text")));
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointBlueprintLibrary_TextPointToString_RoundTripTest, "Schola.Points.Blueprint.TextPointBlueprintLibrary.TextPointToString.RoundTrip", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointBlueprintLibrary_TextPointToString_RoundTripTest::RunTest(const FString& Parameters)
+{
+    FString OriginalValue = TEXT("round trip value");
+
+    TInstancedStruct<FTextPoint> Point = UTextPointBlueprintLibrary::StringToTextPoint(OriginalValue);
+    FString Result = UTextPointBlueprintLibrary::TextPointToString(Point);
+
+    TestEqual(TEXT("Round trip string"), Result, OriginalValue);
+
+    return true;
+}
+
+#endif

--- a/Source/Schola/Private/Test/Points/Blueprint/TextPointBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Points/Blueprint/TextPointBlueprintLibraryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Misc/AutomationTest.h"
 #include "Points/Blueprint/TextPointBlueprintLibrary.h"

--- a/Source/Schola/Private/Test/Points/TextPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/TextPointTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Misc/AutomationTest.h"
 #include "Points/TextPoint.h"

--- a/Source/Schola/Private/Test/Points/TextPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/TextPointTest.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+#include "Points/TextPoint.h"
+
+#if WITH_AUTOMATION_TESTS
+
+// Constructor Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointDefaultConstructorTest, "Schola.Points.TextPoint.Default Constructor Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointDefaultConstructorTest::RunTest(const FString& Parameters)
+{
+	FTextPoint TextPoint = FTextPoint();
+
+	TestTrue(TEXT("TextPoint.Value is empty"), TextPoint.Value.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointFromStringConstructorTest, "Schola.Points.TextPoint.From String Constructor Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointFromStringConstructorTest::RunTest(const FString& Parameters)
+{
+	FTextPoint TextPoint = FTextPoint(TEXT("hello world"));
+
+	TestEqual(TEXT("TextPoint.Value == hello world"), TextPoint.Value, FString(TEXT("hello world")));
+
+	return true;
+}
+
+// Method Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointToStringTest, "Schola.Points.TextPoint.ToString Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointToStringTest::RunTest(const FString& Parameters)
+{
+	FTextPoint TextPoint = FTextPoint(TEXT("hello world"));
+
+	TestEqual(TEXT("TextPoint.ToString() == hello world"), TextPoint.ToString(), FString(TEXT("hello world")));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextPointResetTest, "Schola.Points.TextPoint.Reset Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextPointResetTest::RunTest(const FString& Parameters)
+{
+	FTextPoint TextPoint = FTextPoint(TEXT("hello world"));
+	TextPoint.Reset();
+
+	TestTrue(TEXT("TextPoint.Value is empty after Reset"), TextPoint.Value.IsEmpty());
+
+	return true;
+}
+
+#endif

--- a/Source/Schola/Private/Test/Spaces/Blueprint/SpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/SpaceBlueprintLibraryTest.cpp
@@ -7,6 +7,7 @@
 #include "Spaces/MultiBinarySpace.h"
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/DictSpace.h"
+#include "Spaces/TextSpace.h"
 #include "Common/InstancedStructUtils.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
@@ -86,6 +87,20 @@ bool FSpaceBlueprintLibrary_Type_DictTest::RunTest(const FString& Parameters)
     ESpaceType Result = USpaceBlueprintLibrary::Space_Type(ToUntypedInstancedStruct(Space));
 
     TestEqual(TEXT("Space_Type(DictSpace) == ESpaceType::Dict"), Result, ESpaceType::Dict);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_Type_TextTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.Type.Text", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_Type_TextTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FTextSpace>(16);
+
+    ESpaceType Result = USpaceBlueprintLibrary::Space_Type(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("Space_Type(TextSpace) == ESpaceType::Text"), Result, ESpaceType::Text);
 
     return true;
 }
@@ -172,6 +187,20 @@ bool FSpaceBlueprintLibrary_IsOfType_DictTrueTest::RunTest(const FString& Parame
     bool Result = USpaceBlueprintLibrary::Space_IsOfType(ToUntypedInstancedStruct(Space), ESpaceType::Dict);
 
     TestTrue(TEXT("Space_IsOfType(DictSpace, Dict) == true"), Result);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_IsOfType_TextTrueTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.IsOfType.TextTrue", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_IsOfType_TextTrueTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FTextSpace>(16);
+
+    bool Result = USpaceBlueprintLibrary::Space_IsOfType(ToUntypedInstancedStruct(Space), ESpaceType::Text);
+
+    TestTrue(TEXT("Space_IsOfType(TextSpace, Text) == true"), Result);
 
     return true;
 }

--- a/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+#include "Spaces/Blueprint/TextSpaceBlueprintLibrary.h"
+#include "Spaces/TextSpace.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+// MakeTextSpace Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_FullTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpace.Full", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_MakeTextSpace_FullTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(32, true, 4, TEXT("abc"));
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextSpace& TextSpace = Result.Get<FTextSpace>();
+    TestEqual(TEXT("TextSpace.MaxLength == 32"), TextSpace.MaxLength, 32);
+    TestTrue(TEXT("TextSpace.bHasMinLength == true"), TextSpace.bHasMinLength);
+    TestEqual(TEXT("TextSpace.MinLength == 4"), TextSpace.MinLength, 4);
+    TestEqual(TEXT("TextSpace.Charset == abc"), TextSpace.Charset, FString(TEXT("abc")));
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_MinimalTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpace.Minimal", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_MakeTextSpace_MinimalTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(10, false, 0, FString());
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextSpace& TextSpace = Result.Get<FTextSpace>();
+    TestEqual(TEXT("TextSpace.MaxLength == 10"), TextSpace.MaxLength, 10);
+    TestFalse(TEXT("TextSpace.bHasMinLength == false"), TextSpace.bHasMinLength);
+    TestTrue(TEXT("TextSpace.Charset is empty"), TextSpace.Charset.IsEmpty());
+
+    return true;
+}
+
+// BreakTextSpace Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_BreakTextSpace_BasicTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.BreakTextSpace.Basic", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_BreakTextSpace_BasicTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Space;
+    Space.InitializeAs<FTextSpace>();
+    FTextSpace& TextSpace = Space.GetMutable<FTextSpace>();
+    TextSpace.MaxLength = 16;
+    TextSpace.bHasMinLength = true;
+    TextSpace.MinLength = 2;
+    TextSpace.Charset = TEXT("xyz");
+
+    int32 MaxLength = 0;
+    bool bHasMinLength = false;
+    int32 MinLength = 0;
+    FString Charset;
+    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, bHasMinLength, MinLength, Charset);
+
+    TestEqual(TEXT("MaxLength == 16"), MaxLength, 16);
+    TestTrue(TEXT("bHasMinLength == true"), bHasMinLength);
+    TestEqual(TEXT("MinLength == 2"), MinLength, 2);
+    TestEqual(TEXT("Charset == xyz"), Charset, FString(TEXT("xyz")));
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_BreakTextSpace_RoundTripTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.BreakTextSpace.RoundTrip", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_BreakTextSpace_RoundTripTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Space = UTextSpaceBlueprintLibrary::MakeTextSpace(64, true, 8, TEXT("abcdef"));
+
+    int32 MaxLength = 0;
+    bool bHasMinLength = false;
+    int32 MinLength = 0;
+    FString Charset;
+    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, bHasMinLength, MinLength, Charset);
+
+    TestEqual(TEXT("Round trip MaxLength"), MaxLength, 64);
+    TestTrue(TEXT("Round trip bHasMinLength"), bHasMinLength);
+    TestEqual(TEXT("Round trip MinLength"), MinLength, 8);
+    TestEqual(TEXT("Round trip Charset"), Charset, FString(TEXT("abcdef")));
+
+    return true;
+}
+
+#endif

--- a/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Misc/AutomationTest.h"
 #include "Spaces/Blueprint/TextSpaceBlueprintLibrary.h"

--- a/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
@@ -58,17 +58,18 @@ bool FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AlphanumericTest::RunTes
     return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AnyTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpaceFromPreset.Any", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_EmptyCharsetTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpace.EmptyCharset", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
-bool FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AnyTest::RunTest(const FString& Parameters)
+bool FTextSpaceBlueprintLibrary_MakeTextSpace_EmptyCharsetTest::RunTest(const FString& Parameters)
 {
-    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpaceFromPreset(8, 1, ETextCharsetPreset::Any);
+    // An explicit empty charset is the empty set (only the empty string is a valid point).
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(8, 1, TEXT(""));
 
     TestTrue(TEXT("Result is valid"), Result.IsValid());
 
     const FTextSpace& TextSpace = Result.Get<FTextSpace>();
     TestEqual(TEXT("TextSpace.MaxLength == 8"), TextSpace.MaxLength, 8);
-    TestTrue(TEXT("TextSpace.Charset is empty (no restriction)"), TextSpace.Charset.IsEmpty());
+    TestTrue(TEXT("TextSpace.Charset is empty (the empty set)"), TextSpace.Charset.IsEmpty());
 
     return true;
 }

--- a/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/TextSpaceBlueprintLibraryTest.cpp
@@ -12,13 +12,12 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_FullTe
 
 bool FTextSpaceBlueprintLibrary_MakeTextSpace_FullTest::RunTest(const FString& Parameters)
 {
-    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(32, true, 4, TEXT("abc"));
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(32, 4, TEXT("abc"));
 
     TestTrue(TEXT("Result is valid"), Result.IsValid());
 
     const FTextSpace& TextSpace = Result.Get<FTextSpace>();
     TestEqual(TEXT("TextSpace.MaxLength == 32"), TextSpace.MaxLength, 32);
-    TestTrue(TEXT("TextSpace.bHasMinLength == true"), TextSpace.bHasMinLength);
     TestEqual(TEXT("TextSpace.MinLength == 4"), TextSpace.MinLength, 4);
     TestEqual(TEXT("TextSpace.Charset == abc"), TextSpace.Charset, FString(TEXT("abc")));
 
@@ -29,14 +28,63 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_Minima
 
 bool FTextSpaceBlueprintLibrary_MakeTextSpace_MinimalTest::RunTest(const FString& Parameters)
 {
-    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(10, false, 0, FString());
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(10, 1, FString());
 
     TestTrue(TEXT("Result is valid"), Result.IsValid());
 
     const FTextSpace& TextSpace = Result.Get<FTextSpace>();
     TestEqual(TEXT("TextSpace.MaxLength == 10"), TextSpace.MaxLength, 10);
-    TestFalse(TEXT("TextSpace.bHasMinLength == false"), TextSpace.bHasMinLength);
+    TestEqual(TEXT("TextSpace.MinLength == 1"), TextSpace.MinLength, 1);
     TestTrue(TEXT("TextSpace.Charset is empty"), TextSpace.Charset.IsEmpty());
+
+    return true;
+}
+
+// MakeTextSpaceFromPreset Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AlphanumericTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpaceFromPreset.Alphanumeric", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AlphanumericTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpaceFromPreset(20, 2, ETextCharsetPreset::Alphanumeric);
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextSpace& TextSpace = Result.Get<FTextSpace>();
+    TestEqual(TEXT("TextSpace.MaxLength == 20"), TextSpace.MaxLength, 20);
+    TestEqual(TEXT("TextSpace.MinLength == 2"), TextSpace.MinLength, 2);
+    TestEqual(TEXT("TextSpace.Charset == Alphanumeric preset"), TextSpace.Charset, ScholaTextCharsets::Alphanumeric);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AnyTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpaceFromPreset.Any", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_MakeTextSpaceFromPreset_AnyTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpaceFromPreset(8, 1, ETextCharsetPreset::Any);
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextSpace& TextSpace = Result.Get<FTextSpace>();
+    TestEqual(TEXT("TextSpace.MaxLength == 8"), TextSpace.MaxLength, 8);
+    TestTrue(TEXT("TextSpace.Charset is empty (no restriction)"), TextSpace.Charset.IsEmpty());
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_MakeTextSpace_MinGreaterThanMaxIsClampedTest, "Schola.Spaces.Blueprint.TextSpaceBlueprintLibrary.MakeTextSpace.MinGreaterThanMaxClamped", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceBlueprintLibrary_MakeTextSpace_MinGreaterThanMaxIsClampedTest::RunTest(const FString& Parameters)
+{
+    // MinLength (10) exceeds MaxLength (5); it should be clamped down to MaxLength so the space stays coherent.
+    TInstancedStruct<FTextSpace> Result = UTextSpaceBlueprintLibrary::MakeTextSpace(5, 10, FString());
+
+    TestTrue(TEXT("Result is valid"), Result.IsValid());
+
+    const FTextSpace& TextSpace = Result.Get<FTextSpace>();
+    TestEqual(TEXT("TextSpace.MaxLength == 5"), TextSpace.MaxLength, 5);
+    TestEqual(TEXT("TextSpace.MinLength clamped to 5"), TextSpace.MinLength, 5);
 
     return true;
 }
@@ -51,18 +99,15 @@ bool FTextSpaceBlueprintLibrary_BreakTextSpace_BasicTest::RunTest(const FString&
     Space.InitializeAs<FTextSpace>();
     FTextSpace& TextSpace = Space.GetMutable<FTextSpace>();
     TextSpace.MaxLength = 16;
-    TextSpace.bHasMinLength = true;
     TextSpace.MinLength = 2;
     TextSpace.Charset = TEXT("xyz");
 
     int32 MaxLength = 0;
-    bool bHasMinLength = false;
     int32 MinLength = 0;
     FString Charset;
-    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, bHasMinLength, MinLength, Charset);
+    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, MinLength, Charset);
 
     TestEqual(TEXT("MaxLength == 16"), MaxLength, 16);
-    TestTrue(TEXT("bHasMinLength == true"), bHasMinLength);
     TestEqual(TEXT("MinLength == 2"), MinLength, 2);
     TestEqual(TEXT("Charset == xyz"), Charset, FString(TEXT("xyz")));
 
@@ -73,16 +118,14 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceBlueprintLibrary_BreakTextSpace_Round
 
 bool FTextSpaceBlueprintLibrary_BreakTextSpace_RoundTripTest::RunTest(const FString& Parameters)
 {
-    TInstancedStruct<FTextSpace> Space = UTextSpaceBlueprintLibrary::MakeTextSpace(64, true, 8, TEXT("abcdef"));
+    TInstancedStruct<FTextSpace> Space = UTextSpaceBlueprintLibrary::MakeTextSpace(64, 8, TEXT("abcdef"));
 
     int32 MaxLength = 0;
-    bool bHasMinLength = false;
     int32 MinLength = 0;
     FString Charset;
-    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, bHasMinLength, MinLength, Charset);
+    UTextSpaceBlueprintLibrary::BreakTextSpace(Space, MaxLength, MinLength, Charset);
 
     TestEqual(TEXT("Round trip MaxLength"), MaxLength, 64);
-    TestTrue(TEXT("Round trip bHasMinLength"), bHasMinLength);
     TestEqual(TEXT("Round trip MinLength"), MinLength, 8);
     TestEqual(TEXT("Round trip Charset"), Charset, FString(TEXT("abcdef")));
 

--- a/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+#include "Spaces/TextSpace.h"
+#include "Points/TextPoint.h"
+#include "Points/DiscretePoint.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+// Constructor Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceDefaultTest, "Schola.Spaces.TextSpace.Constructor.Default", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceDefaultTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace();
+
+	TestEqual(TEXT("TextSpace.MaxLength == 0"), TextSpace.MaxLength, 0);
+	TestFalse(TEXT("TextSpace.bHasMinLength == false"), TextSpace.bHasMinLength);
+	TestEqual(TEXT("TextSpace.MinLength == 0"), TextSpace.MinLength, 0);
+	TestTrue(TEXT("TextSpace.Charset is empty"), TextSpace.Charset.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceMaxLengthConstructorTest, "Schola.Spaces.TextSpace.Constructor.MaxLength", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceMaxLengthConstructorTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TestEqual(TEXT("TextSpace.MaxLength == 16"), TextSpace.MaxLength, 16);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceCopyTest, "Schola.Spaces.TextSpace.Copy", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceCopyTest::RunTest(const FString& Parameters)
+{
+	FTextSpace OriginalSpace = FTextSpace();
+	OriginalSpace.MaxLength = 32;
+	OriginalSpace.bHasMinLength = true;
+	OriginalSpace.MinLength = 4;
+	OriginalSpace.Charset = TEXT("abc");
+
+	FTextSpace CopiedSpace = FTextSpace();
+	CopiedSpace.Copy(OriginalSpace);
+
+	TestEqual(TEXT("CopiedSpace.MaxLength == 32"), CopiedSpace.MaxLength, 32);
+	TestTrue(TEXT("CopiedSpace.bHasMinLength == true"), CopiedSpace.bHasMinLength);
+	TestEqual(TEXT("CopiedSpace.MinLength == 4"), CopiedSpace.MinLength, 4);
+	TestEqual(TEXT("CopiedSpace.Charset == abc"), CopiedSpace.Charset, FString(TEXT("abc")));
+
+	return true;
+}
+
+// Method Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceGetNumDimensionsTest, "Schola.Spaces.TextSpace.Get Num Dimensions Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceGetNumDimensionsTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TestEqual(TEXT("TextSpace.GetNumDimensions() == 1"), TextSpace.GetNumDimensions(), 1);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceFlattenedSizeTest, "Schola.Spaces.TextSpace.FlattenedSize Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceFlattenedSizeTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TestEqual(TEXT("TextSpace.GetFlattenedSize() == 16"), TextSpace.GetFlattenedSize(), 16);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceIsEmptyTrueTest, "Schola.Spaces.TextSpace.Is Empty True Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceIsEmptyTrueTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace();
+
+	TestTrue(TEXT("TextSpace.IsEmpty() == true"), TextSpace.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceIsEmptyFalseTest, "Schola.Spaces.TextSpace.Is Empty False Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceIsEmptyFalseTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(8);
+
+	TestFalse(TEXT("TextSpace.IsEmpty() == false"), TextSpace.IsEmpty());
+
+	return true;
+}
+
+// Validation Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateSuccessTest, "Schola.Spaces.TextSpace.Validate Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateSuccessTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == Success"), TextSpace.Validate(Point), ESpaceValidationResult::Success);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateTooLongTest, "Schola.Spaces.TextSpace.Validate Too Long Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateTooLongTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(3);
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateMinLengthSuccessTest, "Schola.Spaces.TextSpace.Validate Min Length Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateMinLengthSuccessTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+	TextSpace.bHasMinLength = true;
+	TextSpace.MinLength = 3;
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == Success"), TextSpace.Validate(Point), ESpaceValidationResult::Success);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateTooShortTest, "Schola.Spaces.TextSpace.Validate Too Short Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateTooShortTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+	TextSpace.bHasMinLength = true;
+	TextSpace.MinLength = 10;
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateCharsetSuccessTest, "Schola.Spaces.TextSpace.Validate Charset Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateCharsetSuccessTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+	TextSpace.Charset = TEXT("abc");
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("cab")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == Success"), TextSpace.Validate(Point), ESpaceValidationResult::Success);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateCharsetViolationTest, "Schola.Spaces.TextSpace.Validate Charset Violation Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateCharsetViolationTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+	TextSpace.Charset = TEXT("abc");
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("abz")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateWrongDataTypeTest, "Schola.Spaces.TextSpace.Validate Wrong Data Type Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateWrongDataTypeTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TInstancedStruct<FPoint> Point;
+	Point.InitializeAs<FDiscretePoint>();
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == WrongDataType"), TextSpace.Validate(Point), ESpaceValidationResult::WrongDataType);
+
+	return true;
+}
+
+#endif

--- a/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Misc/AutomationTest.h"
 #include "Spaces/TextSpace.h"

--- a/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
@@ -16,7 +16,6 @@ bool FTextSpaceDefaultTest::RunTest(const FString& Parameters)
 	FTextSpace TextSpace = FTextSpace();
 
 	TestEqual(TEXT("TextSpace.MaxLength == 0"), TextSpace.MaxLength, 0);
-	TestFalse(TEXT("TextSpace.bHasMinLength == false"), TextSpace.bHasMinLength);
 	TestEqual(TEXT("TextSpace.MinLength == 0"), TextSpace.MinLength, 0);
 	TestTrue(TEXT("TextSpace.Charset is empty"), TextSpace.Charset.IsEmpty());
 
@@ -30,6 +29,7 @@ bool FTextSpaceMaxLengthConstructorTest::RunTest(const FString& Parameters)
 	FTextSpace TextSpace = FTextSpace(16);
 
 	TestEqual(TEXT("TextSpace.MaxLength == 16"), TextSpace.MaxLength, 16);
+	TestEqual(TEXT("TextSpace.MinLength == 1"), TextSpace.MinLength, 1);
 
 	return true;
 }
@@ -40,7 +40,6 @@ bool FTextSpaceCopyTest::RunTest(const FString& Parameters)
 {
 	FTextSpace OriginalSpace = FTextSpace();
 	OriginalSpace.MaxLength = 32;
-	OriginalSpace.bHasMinLength = true;
 	OriginalSpace.MinLength = 4;
 	OriginalSpace.Charset = TEXT("abc");
 
@@ -48,7 +47,6 @@ bool FTextSpaceCopyTest::RunTest(const FString& Parameters)
 	CopiedSpace.Copy(OriginalSpace);
 
 	TestEqual(TEXT("CopiedSpace.MaxLength == 32"), CopiedSpace.MaxLength, 32);
-	TestTrue(TEXT("CopiedSpace.bHasMinLength == true"), CopiedSpace.bHasMinLength);
 	TestEqual(TEXT("CopiedSpace.MinLength == 4"), CopiedSpace.MinLength, 4);
 	TestEqual(TEXT("CopiedSpace.Charset == abc"), CopiedSpace.Charset, FString(TEXT("abc")));
 
@@ -134,7 +132,6 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateMinLengthSuccessTest, "Schola
 bool FTextSpaceValidateMinLengthSuccessTest::RunTest(const FString& Parameters)
 {
 	FTextSpace TextSpace = FTextSpace(16);
-	TextSpace.bHasMinLength = true;
 	TextSpace.MinLength = 3;
 
 	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
@@ -149,7 +146,6 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateTooShortTest, "Schola.Spaces.
 bool FTextSpaceValidateTooShortTest::RunTest(const FString& Parameters)
 {
 	FTextSpace TextSpace = FTextSpace(16);
-	TextSpace.bHasMinLength = true;
 	TextSpace.MinLength = 10;
 
 	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hello")));
@@ -181,6 +177,37 @@ bool FTextSpaceValidateCharsetViolationTest::RunTest(const FString& Parameters)
 	TextSpace.Charset = TEXT("abc");
 
 	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("abz")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetAlphanumericSuccessTest, "Schola.Spaces.TextSpace.Validate Empty Charset Alphanumeric Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateEmptyCharsetAlphanumericSuccessTest::RunTest(const FString& Parameters)
+{
+	// An empty charset is treated as Gymnasium's alphanumeric default, so a purely
+	// alphanumeric string should still validate successfully.
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("abc123")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == Success"), TextSpace.Validate(Point), ESpaceValidationResult::Success);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetNonAlphanumericViolationTest, "Schola.Spaces.TextSpace.Validate Empty Charset Non Alphanumeric Violation Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateEmptyCharsetNonAlphanumericViolationTest::RunTest(const FString& Parameters)
+{
+	// With an empty charset aligned to Gymnasium's alphanumeric default, a string with
+	// a non-alphanumeric character (here a space) must be rejected so it cannot be sent
+	// to Python where it would fall outside the deserialized Text space's charset.
+	FTextSpace TextSpace = FTextSpace(16);
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hi there")));
 
 	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
 

--- a/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
@@ -17,7 +17,7 @@ bool FTextSpaceDefaultTest::RunTest(const FString& Parameters)
 
 	TestEqual(TEXT("TextSpace.MaxLength == 0"), TextSpace.MaxLength, 0);
 	TestEqual(TEXT("TextSpace.MinLength == 0"), TextSpace.MinLength, 0);
-	TestTrue(TEXT("TextSpace.Charset is empty"), TextSpace.Charset.IsEmpty());
+	TestEqual(TEXT("TextSpace.Charset defaults to alphanumeric"), TextSpace.Charset, FString(ScholaTextCharsets::Alphanumeric));
 
 	return true;
 }
@@ -183,12 +183,12 @@ bool FTextSpaceValidateCharsetViolationTest::RunTest(const FString& Parameters)
 	return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetAlphanumericSuccessTest, "Schola.Spaces.TextSpace.Validate Empty Charset Alphanumeric Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateDefaultCharsetAlphanumericSuccessTest, "Schola.Spaces.TextSpace.Validate Default Charset Alphanumeric Success Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
-bool FTextSpaceValidateEmptyCharsetAlphanumericSuccessTest::RunTest(const FString& Parameters)
+bool FTextSpaceValidateDefaultCharsetAlphanumericSuccessTest::RunTest(const FString& Parameters)
 {
-	// An empty charset is treated as Gymnasium's alphanumeric default, so a purely
-	// alphanumeric string should still validate successfully.
+	// The default charset is Gymnasium's alphanumeric set, so a purely alphanumeric
+	// string validates successfully.
 	FTextSpace TextSpace = FTextSpace(16);
 
 	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("abc123")));
@@ -198,18 +198,31 @@ bool FTextSpaceValidateEmptyCharsetAlphanumericSuccessTest::RunTest(const FStrin
 	return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetNonAlphanumericViolationTest, "Schola.Spaces.TextSpace.Validate Empty Charset Non Alphanumeric Violation Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetRejectsNonEmptyTest, "Schola.Spaces.TextSpace.Validate Empty Charset Rejects Non Empty Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
-bool FTextSpaceValidateEmptyCharsetNonAlphanumericViolationTest::RunTest(const FString& Parameters)
+bool FTextSpaceValidateEmptyCharsetRejectsNonEmptyTest::RunTest(const FString& Parameters)
 {
-	// With an empty charset aligned to Gymnasium's alphanumeric default, a string with
-	// a non-alphanumeric character (here a space) must be rejected so it cannot be sent
-	// to Python where it would fall outside the deserialized Text space's charset.
-	FTextSpace TextSpace = FTextSpace(16);
+	// An empty charset is the empty set: no character is permitted, so any non-empty
+	// string is rejected.
+	FTextSpace TextSpace = FTextSpace(16, 0, TEXT(""));
 
-	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("hi there")));
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("a")));
 
 	TestEqual(TEXT("TextSpace.Validate(Point) == OutOfBounds"), TextSpace.Validate(Point), ESpaceValidationResult::OutOfBounds);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceValidateEmptyCharsetAcceptsEmptyStringTest, "Schola.Spaces.TextSpace.Validate Empty Charset Accepts Empty String Test", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceValidateEmptyCharsetAcceptsEmptyStringTest::RunTest(const FString& Parameters)
+{
+	// With an empty charset (empty set) and MinLength 0, only the empty string is valid.
+	FTextSpace TextSpace = FTextSpace(16, 0, TEXT(""));
+
+	TInstancedStruct<FPoint> Point = TInstancedStruct<FPoint>::Make<FTextPoint>(FTextPoint(TEXT("")));
+
+	TestEqual(TEXT("TextSpace.Validate(Point) == Success"), TextSpace.Validate(Point), ESpaceValidationResult::Success);
 
 	return true;
 }

--- a/Source/Schola/Public/Common/BlueprintErrorUtils.h
+++ b/Source/Schola/Public/Common/BlueprintErrorUtils.h
@@ -10,6 +10,28 @@
 #endif
 
 /**
+ * @brief Raises a non-fatal Blueprint script error with a custom message.
+ * @param InFunctionName The name of the function where the error occurred.
+ * @param InMessage The error message describing what went wrong.
+ */
+inline void RaiseBlueprintError(const FString& InFunctionName, const FString& InMessage)
+{
+#if !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
+	FFrame* TopFrame = FFrame::GetThreadLocalTopStackFrame();
+	if (TopFrame)
+	{
+		const FString ErrorMessage = FString::Printf(TEXT("%s: %s"), *InFunctionName, *InMessage);
+	#if WITH_EDITOR
+		const FBlueprintExceptionInfo ExceptionInfo(EBlueprintExceptionType::NonFatalError, FText::FromString(ErrorMessage));
+		FBlueprintCoreDelegates::ThrowScriptException(TopFrame->Object, *TopFrame, ExceptionInfo);
+	#else
+		UE_LOG(LogBlueprintUserMessages, Error, TEXT("%s:\n%s"), *ErrorMessage, *TopFrame->GetStackTrace());
+	#endif	// WITH_EDITOR
+	}
+#endif	// !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
+}
+
+/**
  * @brief Raises a Blueprint script error when an invalid InstancedStruct is passed.
  * @param InFunctionName The name of the function where the error occurred.
  */

--- a/Source/Schola/Public/Common/BlueprintErrorUtils.h
+++ b/Source/Schola/Public/Common/BlueprintErrorUtils.h
@@ -37,19 +37,7 @@ inline void RaiseBlueprintError(const FString& InFunctionName, const FString& In
  */
 inline void RaiseInvalidInstancedStructError(const FString& InFunctionName)
 {
-#if !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
-	FFrame* TopFrame = FFrame::GetThreadLocalTopStackFrame();
-	if (TopFrame)
-	{
-		const FString ErrorMessage = FString::Printf(TEXT("%s: Invalid InstancedStruct passed."), *InFunctionName);
-	#if WITH_EDITOR
-		const FBlueprintExceptionInfo ExceptionInfo(EBlueprintExceptionType::NonFatalError, FText::FromString(ErrorMessage));
-		FBlueprintCoreDelegates::ThrowScriptException(TopFrame->Object, *TopFrame, ExceptionInfo);
-	#else
-		UE_LOG(LogBlueprintUserMessages, Error, TEXT("%s:\n%s"), *ErrorMessage, *TopFrame->GetStackTrace());
-	#endif	// WITH_EDITOR
-	}
-#endif	// !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
+	RaiseBlueprintError(InFunctionName, TEXT("Invalid InstancedStruct passed."));
 }
 
 /**
@@ -62,20 +50,8 @@ inline void RaiseInvalidInstancedStructError(const FString& InFunctionName)
 template<typename T>
 inline void RaiseInstancedStructTypeMismatchError(const TInstancedStruct<T>& InStruct, const FString& ExpectedType, const FString& InFunctionName)
 {
-#if !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
-	FFrame* TopFrame = FFrame::GetThreadLocalTopStackFrame();
-	if (TopFrame)
-	{
-		const FString ErrorMessage = FString::Printf(TEXT("%s: Type mismatch. Expected %s but received %s."), 
-			*InFunctionName, *ExpectedType, *InStruct.GetScriptStruct()->GetName());
-	#if WITH_EDITOR
-		const FBlueprintExceptionInfo ExceptionInfo(EBlueprintExceptionType::NonFatalError, FText::FromString(ErrorMessage));
-		FBlueprintCoreDelegates::ThrowScriptException(TopFrame->Object, *TopFrame, ExceptionInfo);
-	#else
-		UE_LOG(LogBlueprintUserMessages, Error, TEXT("%s:\n%s"), *ErrorMessage, *TopFrame->GetStackTrace());
-	#endif	// WITH_EDITOR
-	}
-#endif	// !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
+	RaiseBlueprintError(InFunctionName, FString::Printf(TEXT("Type mismatch. Expected %s but received %s."),
+		*ExpectedType, *InStruct.GetScriptStruct()->GetName()));
 }
 
 /**
@@ -84,20 +60,8 @@ inline void RaiseInstancedStructTypeMismatchError(const TInstancedStruct<T>& InS
  * @param ExpectedType The expected type name.
  * @param InFunctionName The name of the function where the error occurred.
  */
- inline void RaiseInstancedStructTypeMismatchError(const FInstancedStruct& InStruct, const FString& ExpectedType, const FString& InFunctionName)
- {
- #if !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
-	 FFrame* TopFrame = FFrame::GetThreadLocalTopStackFrame();
-	 if (TopFrame)
-	 {
-		 const FString ErrorMessage = FString::Printf(TEXT("%s: Type mismatch. Expected %s but received %s."), 
-			 *InFunctionName, *ExpectedType, *InStruct.GetScriptStruct()->GetName());
-	 #if WITH_EDITOR
-		 const FBlueprintExceptionInfo ExceptionInfo(EBlueprintExceptionType::NonFatalError, FText::FromString(ErrorMessage));
-		 FBlueprintCoreDelegates::ThrowScriptException(TopFrame->Object, *TopFrame, ExceptionInfo);
-	 #else
-		 UE_LOG(LogBlueprintUserMessages, Error, TEXT("%s:\n%s"), *ErrorMessage, *TopFrame->GetStackTrace());
-	 #endif	// WITH_EDITOR
-	 }
- #endif	// !(UE_BUILD_TEST || UE_BUILD_SHIPPING)
- }
+inline void RaiseInstancedStructTypeMismatchError(const FInstancedStruct& InStruct, const FString& ExpectedType, const FString& InFunctionName)
+{
+	RaiseBlueprintError(InFunctionName, FString::Printf(TEXT("Type mismatch. Expected %s but received %s."),
+		*ExpectedType, *InStruct.GetScriptStruct()->GetName()));
+}

--- a/Source/Schola/Public/Common/BlueprintErrorUtils.h
+++ b/Source/Schola/Public/Common/BlueprintErrorUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Public/Common/SpaceTransmuter.h
+++ b/Source/Schola/Public/Common/SpaceTransmuter.h
@@ -52,6 +52,12 @@ public:
 	virtual void operator()(const FDictSpace& Space) override;
 
 	/**
+	 * @brief Processes a text space for serialization.
+	 * @param[in] Space The text space to process.
+	 */
+	virtual void operator()(const FTextSpace& Space) override;
+
+	/**
 	 * @brief Builds and returns a new buffer containing the serialized space.
 	 * @return Pointer to the newly created buffer.
 	 */

--- a/Source/Schola/Public/Points/Blueprint/TextPointBlueprintLibrary.h
+++ b/Source/Schola/Public/Points/Blueprint/TextPointBlueprintLibrary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Public/Points/Blueprint/TextPointBlueprintLibrary.h
+++ b/Source/Schola/Public/Points/Blueprint/TextPointBlueprintLibrary.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "StructUtils/InstancedStruct.h"
+#include "Points/Point.h"
+#include "Points/TextPoint.h"
+#include "TextPointBlueprintLibrary.generated.h"
+
+/**
+ * @class UTextPointBlueprintLibrary
+ * @brief Blueprint oriented helper functions for creating & inspecting Text Point InstancedStructs.
+ * 
+ * This library provides utility functions for creating and manipulating Text Point instances
+ * from within Blueprints. These return TInstancedStruct<FTextPoint>.
+ */
+UCLASS()
+class SCHOLA_API UTextPointBlueprintLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+
+    /**
+     * @brief Converts a string value to a text point.
+     * @param[in] InValue The string value to wrap in a text point.
+     * @return A new text point instance.
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Point|Text", meta=(DisplayName="From String (Text Point)"))
+    static TInstancedStruct<FTextPoint> StringToTextPoint(UPARAM(DisplayName="Value") const FString& InValue);
+
+    /**
+     * @brief Converts a text point to its string value.
+     * @param[in] InTextPoint The text point to convert.
+     * @return The string value stored in the text point.
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Point|Text", meta=(BlueprintAutocast, DisplayName="To String (Text Point)", CompactNodeTitle="->"))
+    static FString TextPointToString(UPARAM(DisplayName="Text Point") const TInstancedStruct<FTextPoint>& InTextPoint);
+
+};

--- a/Source/Schola/Public/Points/Point.h
+++ b/Source/Schola/Public/Points/Point.h
@@ -88,6 +88,7 @@ struct TBaseStructure<FPoint>
 	 Discrete        UMETA(DisplayName="Discrete"),      ///< Discrete point with a single integer value
 	 MultiDiscrete   UMETA(DisplayName="MultiDiscrete"), ///< Multi-discrete point with multiple integer values
 	 Box             UMETA(DisplayName="Box"),           ///< Box point with continuous float values
-	 Dict            UMETA(DisplayName="Dict")           ///< Dictionary point containing named sub-points
+	 Dict            UMETA(DisplayName="Dict"),          ///< Dictionary point containing named sub-points
+	 Text            UMETA(DisplayName="Text")           ///< Text point holding a string value
  };
  

--- a/Source/Schola/Public/Points/PointVisitor.h
+++ b/Source/Schola/Public/Points/PointVisitor.h
@@ -7,6 +7,7 @@ struct FDiscretePoint;
 struct FMultiDiscretePoint;
 struct FBoxPoint;
 struct FDictPoint;
+struct FTextPoint;
 
 /**
  * @class PointVisitor
@@ -49,6 +50,12 @@ public:
 	 * @param[in,out] Point The MultiDiscretePoint to visit.
 	 */
 	virtual void operator()(FMultiDiscretePoint& Point){};
+
+	/**
+	 * @brief Visits a TextPoint.
+	 * @param[in,out] Point The TextPoint to visit.
+	 */
+	virtual void operator()(FTextPoint& Point){};
 
 };
 
@@ -93,4 +100,10 @@ public:
 	 * @param[in] Point The const MultiDiscretePoint to visit.
 	 */
 	virtual void operator()(const FMultiDiscretePoint& Point){};
+
+	/**
+	 * @brief Visits a const TextPoint.
+	 * @param[in] Point The const TextPoint to visit.
+	 */
+	virtual void operator()(const FTextPoint& Point){};
 };

--- a/Source/Schola/Public/Points/TextPoint.h
+++ b/Source/Schola/Public/Points/TextPoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Public/Points/TextPoint.h
+++ b/Source/Schola/Public/Points/TextPoint.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Points/Point.h"
+#include "Points/PointVisitor.h"
+#include "TextPoint.generated.h"
+
+/**
+ * @struct FTextPoint
+ * @brief A point in a text space holding a single string value.
+ * 
+ * Text points represent a string sampled from a text space, constrained by
+ * the space's length bounds and optional character set. Commonly used for
+ * text-based observations or actions.
+ */
+USTRUCT(BlueprintType)
+struct SCHOLA_API FTextPoint : public FPoint
+{
+	GENERATED_BODY()
+
+	/**
+	 * @brief The string value of this point.
+	 */
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "Point")
+	FString Value = TEXT("");
+
+	/**
+	 * @brief Constructs an empty TextPoint with an empty string.
+	 */
+	FTextPoint()
+		: Value(TEXT(""))
+	{
+	}
+
+	/**
+	 * @brief Constructs a TextPoint with a specific string value.
+	 * @param[in] Value The string value to initialize the point with.
+	 */
+	FTextPoint(const FString& Value)
+		: Value(Value)
+	{
+	}
+
+	/**
+	 * @brief Virtual destructor.
+	 */
+	virtual ~FTextPoint()
+	{
+	}
+
+	/**
+	 * @brief Accepts a mutable visitor for the visitor pattern.
+	 * @param[in,out] Visitor The visitor to accept.
+	 */
+	void Accept(PointVisitor& Visitor) override;
+
+	/**
+	 * @brief Accepts a const visitor for the visitor pattern.
+	 * @param[in,out] Visitor The const visitor to accept.
+	 */
+	void Accept(ConstPointVisitor& Visitor) const override;
+
+	/**
+	 * @brief Resets the value of the TextPoint to an empty string.
+	 */
+	void Reset() override
+	{
+		this->Value.Empty();
+	};
+
+	/**
+	 * @brief Converts this point to a string representation.
+	 * @return The string value of this point.
+	 */
+	FString ToString() const override
+	{
+		return this->Value;
+	}
+};

--- a/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
+++ b/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "StructUtils/InstancedStruct.h"
+#include "Spaces/Space.h"
+#include "Spaces/TextSpace.h"
+#include "TextSpaceBlueprintLibrary.generated.h"
+
+/**
+ * @class UTextSpaceBlueprintLibrary
+ * @brief Blueprint oriented helper functions for creating & inspecting Text Space InstancedStructs.
+ * 
+ * This library provides utility functions for creating and manipulating Text Space instances
+ * from within Blueprints. These return TInstancedStruct<FTextSpace>.
+ */
+UCLASS()
+class SCHOLA_API UTextSpaceBlueprintLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+
+    /**
+     * @brief Creates a text space from its length bounds and optional character set.
+     * @param[in] InMaxLength The maximum allowed string length (inclusive).
+     * @param[in] bInHasMinLength Whether a minimum length constraint is enforced.
+     * @param[in] InMinLength The minimum allowed string length (inclusive). Only used when bInHasMinLength is true.
+     * @param[in] InCharset The set of allowed characters. An empty string applies no charset restriction in C++, but maps to Gymnasium's default (alphanumeric) set when exchanged with Python.
+     * @return A new text space instance.
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(AutoCreateRefTerm="InCharset", DisplayName="Make Text Space"))
+    static TInstancedStruct<FTextSpace> MakeTextSpace(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Has Min Length") bool bInHasMinLength, UPARAM(DisplayName="Min Length") int32 InMinLength, UPARAM(DisplayName="Charset") const FString& InCharset);
+
+    /**
+     * @brief Breaks a text space into its length bounds and character set.
+     * @param[in] InTextSpace The text space to break apart.
+     * @param[out] OutMaxLength Output parameter that receives the maximum length.
+     * @param[out] bOutHasMinLength Output parameter that receives whether a minimum length is enforced.
+     * @param[out] OutMinLength Output parameter that receives the minimum length.
+     * @param[out] OutCharset Output parameter that receives the character set.
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Break Text Space"))
+    static void BreakTextSpace(UPARAM(DisplayName="Text Space") const TInstancedStruct<FTextSpace>& InTextSpace, UPARAM(DisplayName="Max Length") int32& OutMaxLength, UPARAM(DisplayName="Has Min Length") bool& bOutHasMinLength, UPARAM(DisplayName="Min Length") int32& OutMinLength, UPARAM(DisplayName="Charset") FString& OutCharset);
+
+};

--- a/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
+++ b/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
@@ -25,21 +25,21 @@ public:
      * @brief Creates a text space from its length bounds and optional character set.
      * @param[in] InMaxLength The maximum allowed string length (inclusive).
      * @param[in] InMinLength The minimum allowed string length (inclusive). Defaults to 1, matching Gymnasium.
-     * @param[in] InCharset The set of allowed characters. An empty string applies no charset restriction in C++, but maps to Gymnasium's default (alphanumeric) set when exchanged with Python. Use GetTextCharsetPreset for common sets.
+     * @param[in] InCharset The set of allowed characters, taken literally. An empty string denotes the empty set (only the empty string is valid). Defaults to Gymnasium's alphanumeric set. Use GetTextCharsetPreset for common sets.
      * @return A new text space instance.
      */
     UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Make Text Space"))
-    static TInstancedStruct<FTextSpace> MakeTextSpace(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset") const FString& InCharset = TEXT(""));
+    static TInstancedStruct<FTextSpace> MakeTextSpace(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset") const FString& InCharset = TEXT("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"));
 
     /**
      * @brief Creates a text space from its length bounds and a character-set preset.
      * @param[in] InMaxLength The maximum allowed string length (inclusive).
      * @param[in] InMinLength The minimum allowed string length (inclusive). Defaults to 1, matching Gymnasium.
-     * @param[in] InCharsetPreset The character-set preset to use. ETextCharsetPreset::Any applies no restriction.
+     * @param[in] InCharsetPreset The character-set preset to use. Defaults to Alphanumeric to match Gymnasium. To use an empty set, call MakeTextSpace with an empty charset instead.
      * @return A new text space instance.
      */
     UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Make Text Space From Preset"))
-    static TInstancedStruct<FTextSpace> MakeTextSpaceFromPreset(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset Preset") ETextCharsetPreset InCharsetPreset = ETextCharsetPreset::Any);
+    static TInstancedStruct<FTextSpace> MakeTextSpaceFromPreset(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset Preset") ETextCharsetPreset InCharsetPreset = ETextCharsetPreset::Alphanumeric);
 
     /**
      * @brief Breaks a text space into its length bounds and character set.
@@ -54,7 +54,7 @@ public:
     /**
      * @brief Returns the character-set string for a given preset.
      * @param[in] InPreset The preset to resolve.
-     * @return The matching character-set string. ETextCharsetPreset::Any returns an empty string (no restriction).
+     * @return The matching character-set string for the preset.
      */
     UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Get Text Charset Preset"))
     static FString GetTextCharsetPreset(UPARAM(DisplayName="Preset") ETextCharsetPreset InPreset);

--- a/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
+++ b/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
+++ b/Source/Schola/Public/Spaces/Blueprint/TextSpaceBlueprintLibrary.h
@@ -24,23 +24,39 @@ public:
     /**
      * @brief Creates a text space from its length bounds and optional character set.
      * @param[in] InMaxLength The maximum allowed string length (inclusive).
-     * @param[in] bInHasMinLength Whether a minimum length constraint is enforced.
-     * @param[in] InMinLength The minimum allowed string length (inclusive). Only used when bInHasMinLength is true.
-     * @param[in] InCharset The set of allowed characters. An empty string applies no charset restriction in C++, but maps to Gymnasium's default (alphanumeric) set when exchanged with Python.
+     * @param[in] InMinLength The minimum allowed string length (inclusive). Defaults to 1, matching Gymnasium.
+     * @param[in] InCharset The set of allowed characters. An empty string applies no charset restriction in C++, but maps to Gymnasium's default (alphanumeric) set when exchanged with Python. Use GetTextCharsetPreset for common sets.
      * @return A new text space instance.
      */
-    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(AutoCreateRefTerm="InCharset", DisplayName="Make Text Space"))
-    static TInstancedStruct<FTextSpace> MakeTextSpace(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Has Min Length") bool bInHasMinLength, UPARAM(DisplayName="Min Length") int32 InMinLength, UPARAM(DisplayName="Charset") const FString& InCharset);
+    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Make Text Space"))
+    static TInstancedStruct<FTextSpace> MakeTextSpace(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset") const FString& InCharset = TEXT(""));
+
+    /**
+     * @brief Creates a text space from its length bounds and a character-set preset.
+     * @param[in] InMaxLength The maximum allowed string length (inclusive).
+     * @param[in] InMinLength The minimum allowed string length (inclusive). Defaults to 1, matching Gymnasium.
+     * @param[in] InCharsetPreset The character-set preset to use. ETextCharsetPreset::Any applies no restriction.
+     * @return A new text space instance.
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Make Text Space From Preset"))
+    static TInstancedStruct<FTextSpace> MakeTextSpaceFromPreset(UPARAM(DisplayName="Max Length") int32 InMaxLength, UPARAM(DisplayName="Min Length") int32 InMinLength = 1, UPARAM(DisplayName="Charset Preset") ETextCharsetPreset InCharsetPreset = ETextCharsetPreset::Any);
 
     /**
      * @brief Breaks a text space into its length bounds and character set.
      * @param[in] InTextSpace The text space to break apart.
      * @param[out] OutMaxLength Output parameter that receives the maximum length.
-     * @param[out] bOutHasMinLength Output parameter that receives whether a minimum length is enforced.
      * @param[out] OutMinLength Output parameter that receives the minimum length.
      * @param[out] OutCharset Output parameter that receives the character set.
      */
     UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Break Text Space"))
-    static void BreakTextSpace(UPARAM(DisplayName="Text Space") const TInstancedStruct<FTextSpace>& InTextSpace, UPARAM(DisplayName="Max Length") int32& OutMaxLength, UPARAM(DisplayName="Has Min Length") bool& bOutHasMinLength, UPARAM(DisplayName="Min Length") int32& OutMinLength, UPARAM(DisplayName="Charset") FString& OutCharset);
+    static void BreakTextSpace(UPARAM(DisplayName="Text Space") const TInstancedStruct<FTextSpace>& InTextSpace, UPARAM(DisplayName="Max Length") int32& OutMaxLength, UPARAM(DisplayName="Min Length") int32& OutMinLength, UPARAM(DisplayName="Charset") FString& OutCharset);
+
+    /**
+     * @brief Returns the character-set string for a given preset.
+     * @param[in] InPreset The preset to resolve.
+     * @return The matching character-set string. ETextCharsetPreset::Any returns an empty string (no restriction).
+     */
+    UFUNCTION(BlueprintPure, Category="Schola|Space|Text", meta=(DisplayName="Get Text Charset Preset"))
+    static FString GetTextCharsetPreset(UPARAM(DisplayName="Preset") ETextCharsetPreset InPreset);
 
 };

--- a/Source/Schola/Public/Spaces/PointAllocator.h
+++ b/Source/Schola/Public/Spaces/PointAllocator.h
@@ -8,12 +8,14 @@
 #include "Points/MultiDiscretePoint.h"
 #include "Points/BoxPoint.h"
 #include "Points/DictPoint.h"
+#include "Points/TextPoint.h"
 // Space type headers (needed for field access in allocation)
 #include "Spaces/MultiBinarySpace.h"
 #include "Spaces/DiscreteSpace.h"
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
 #include "Spaces/DictSpace.h"
+#include "Spaces/TextSpace.h"
 
 
 /**
@@ -77,6 +79,15 @@ public:
 		PointToAllocate.InitializeAs<FBoxPoint>();
 		FBoxPoint& P = PointToAllocate.GetMutable<FBoxPoint>();
 		P.Values.Init(0.0f, InSpace.Dimensions.Num());
+	}
+
+	/**
+	 * @brief Allocates a TextPoint for a TextSpace.
+	 * @param[in] InSpace The TextSpace to allocate for.
+	 */
+	void operator()(const FTextSpace& InSpace) override
+	{
+		PointToAllocate.InitializeAs<FTextPoint>();
 	}
 
 	/**

--- a/Source/Schola/Public/Spaces/Space.h
+++ b/Source/Schola/Public/Spaces/Space.h
@@ -23,7 +23,8 @@ class ConstSpaceVisitor;
 	 Discrete        UMETA(DisplayName="Discrete"),      ///< Discrete space with integer choices
 	 MultiDiscrete   UMETA(DisplayName="MultiDiscrete"), ///< Multi-discrete space with multiple integer choices
 	 Box             UMETA(DisplayName="Box"),           ///< Box space with continuous float ranges
-	 Dict            UMETA(DisplayName="Dict")           ///< Dictionary space containing named sub-spaces
+	 Dict            UMETA(DisplayName="Dict"),          ///< Dictionary space containing named sub-spaces
+	 Text            UMETA(DisplayName="Text")           ///< Text space with variable-length strings
  };
 
  

--- a/Source/Schola/Public/Spaces/SpaceVisitor.h
+++ b/Source/Schola/Public/Spaces/SpaceVisitor.h
@@ -7,6 +7,7 @@ struct FDiscreteSpace;
 struct FBoxSpace;
 struct FDictSpace;
 struct FMultiDiscreteSpace;
+struct FTextSpace;
 
 /**
  * @class SpaceVisitor
@@ -49,6 +50,12 @@ public:
 	 * @param[in,out] Space The DictSpace to visit.
 	 */
 	virtual void operator()(FDictSpace& Space){};
+
+	/**
+	 * @brief Visits a TextSpace.
+	 * @param[in,out] Space The TextSpace to visit.
+	 */
+	virtual void operator()(FTextSpace& Space){};
 
 };
 
@@ -93,5 +100,11 @@ public:
 	 * @param[in] Space The const DictSpace to visit.
 	 */
 	virtual void operator()(const FDictSpace& Space){};
+
+	/**
+	 * @brief Visits a const TextSpace.
+	 * @param[in] Space The const TextSpace to visit.
+	 */
+	virtual void operator()(const FTextSpace& Space){};
 
 };

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -13,8 +13,6 @@
  */
 namespace ScholaTextCharsets
 {
-	/** No restriction - any character is allowed (full UTF-8). */
-	inline constexpr const TCHAR* Any = TEXT("");
 	/** ASCII digits 0-9. */
 	inline constexpr const TCHAR* Numeric = TEXT("0123456789");
 	/** ASCII letters a-z and A-Z. */
@@ -30,8 +28,6 @@ namespace ScholaTextCharsets
 UENUM(BlueprintType)
 enum class ETextCharsetPreset : uint8
 {
-	/** No charset restriction (any character is allowed, i.e. full UTF-8). */
-	Any UMETA(DisplayName = "Any (UTF-8)"),
 	/** ASCII digits 0-9. */
 	Numeric UMETA(DisplayName = "Numeric"),
 	/** ASCII letters a-z and A-Z. */
@@ -45,8 +41,8 @@ enum class ETextCharsetPreset : uint8
  * @brief A struct representing a space of variable-length strings.
  * 
  * A text space represents a string whose length is bounded by [MinLength, MaxLength]
- * and whose characters are optionally restricted to a fixed character set. This mirrors
- * the gymnasium Text space and is commonly used for text-based observations or actions.
+ * and whose characters are restricted to a fixed character set (defaulting to alphanumeric).
+ * This mirrors the gymnasium Text space and is commonly used for text-based observations or actions.
  */
 USTRUCT(BlueprintType)
 struct SCHOLA_API FTextSpace : public FSpace
@@ -71,14 +67,14 @@ public:
 
 	/**
 	 * @brief The set of characters allowed in strings in this space.
-	 * 
-	 * An empty charset is treated as Gymnasium's default (alphanumeric) set, both for
-	 * C++ validation and when exchanged with Python. Gymnasium's Text space always has
-	 * a finite charset (there is no "unrestricted" option), so aligning on the default
-	 * keeps validation consistent across the language boundary.
+	 *
+	 * The charset is taken literally: it is the exact set of permitted characters and
+	 * maps directly to Gymnasium's character_set. An empty charset is the empty set.
+	 * Defaults to Gymnasium's alphanumeric set so a default-constructed space matches
+	 * Gymnasium's Text default.
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Character Set"))
-	FString Charset = TEXT("");
+	FString Charset = ScholaTextCharsets::Alphanumeric;
 
 	/**
 	 * @brief Constructs an empty TextSpace with MaxLength=0.
@@ -98,7 +94,7 @@ public:
 	 * @brief Constructs a TextSpace from its length bounds and character set.
 	 * @param MaxLength The maximum allowed string length.
 	 * @param MinLength The minimum allowed string length.
-	 * @param Charset The set of allowed characters. An empty string applies no restriction.
+	 * @param Charset The set of allowed characters, taken literally. An empty string denotes the empty set.
 	 */
 	FTextSpace(int MaxLength, int MinLength, const FString& Charset)
 		: MaxLength(MaxLength), MinLength(MinLength), Charset(Charset)

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -8,6 +8,39 @@
 #include "TextSpace.generated.h"
 
 /**
+ * @namespace ScholaTextCharsets
+ * @brief Common character-set presets for use with FTextSpace::Charset.
+ */
+namespace ScholaTextCharsets
+{
+	/** No restriction - any character is allowed (full UTF-8). */
+	inline constexpr const TCHAR* Any = TEXT("");
+	/** ASCII digits 0-9. */
+	inline constexpr const TCHAR* Numeric = TEXT("0123456789");
+	/** ASCII letters a-z and A-Z. */
+	inline constexpr const TCHAR* Alphabetic = TEXT("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+	/** ASCII digits and letters (matches Gymnasium's default alphanumeric set). */
+	inline constexpr const TCHAR* Alphanumeric = TEXT("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+}
+
+/**
+ * @enum ETextCharsetPreset
+ * @brief Selectable character-set presets for building an FTextSpace charset.
+ */
+UENUM(BlueprintType)
+enum class ETextCharsetPreset : uint8
+{
+	/** No charset restriction (any character is allowed, i.e. full UTF-8). */
+	Any UMETA(DisplayName = "Any (UTF-8)"),
+	/** ASCII digits 0-9. */
+	Numeric UMETA(DisplayName = "Numeric"),
+	/** ASCII letters a-z and A-Z. */
+	Alphabetic UMETA(DisplayName = "Alphabetic"),
+	/** ASCII digits and letters (Gymnasium's default). */
+	Alphanumeric UMETA(DisplayName = "Alphanumeric"),
+};
+
+/**
  * @struct FTextSpace
  * @brief A struct representing a space of variable-length strings.
  * 
@@ -24,30 +57,25 @@ public:
 	/**
 	 * @brief The maximum allowed length (inclusive) of strings in this space.
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Maximum Length"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Maximum Length", ClampMin = "0"))
 	int MaxLength = 0;
 
 	/**
-	 * @brief Whether a minimum length constraint is set for this space.
-	 * 
-	 * When false, MinLength is ignored and the effective minimum length is 0.
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Has Minimum Length", InlineEditConditionToggle))
-	bool bHasMinLength = false;
-
-	/**
 	 * @brief The minimum allowed length (inclusive) of strings in this space.
-	 * 
-	 * Only enforced when bHasMinLength is true.
+	 *
+	 * Defaults to 0 so an empty (MaxLength == 0) space stays coherent (MinLength <= MaxLength).
+	 * The length constructors and the Make Text Space node default this to 1 to match Gymnasium.
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Minimum Length", EditCondition = "bHasMinLength"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Minimum Length", ClampMin = "0"))
 	int MinLength = 0;
 
 	/**
 	 * @brief The set of characters allowed in strings in this space.
 	 * 
-	 * An empty charset applies no restriction in C++, but maps to Gymnasium's
-	 * default (alphanumeric) set when exchanged with Python.
+	 * An empty charset is treated as Gymnasium's default (alphanumeric) set, both for
+	 * C++ validation and when exchanged with Python. Gymnasium's Text space always has
+	 * a finite charset (there is no "unrestricted" option), so aligning on the default
+	 * keeps validation consistent across the language boundary.
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Character Set"))
 	FString Charset = TEXT("");
@@ -60,18 +88,24 @@ public:
 	/**
 	 * @brief Constructs a TextSpace with a specific maximum length.
 	 * @param MaxLength The maximum allowed string length.
+	 *
+	 * MinLength defaults to 1 (matching Gymnasium) when MaxLength is positive, and 0 otherwise
+	 * so the space stays coherent (MinLength <= MaxLength).
 	 */
-	FTextSpace(int MaxLength) : MaxLength(MaxLength) {};
+	FTextSpace(int MaxLength) : MaxLength(MaxLength), MinLength(MaxLength > 0 ? 1 : 0) {};
 
 	/**
 	 * @brief Constructs a TextSpace from its length bounds and character set.
 	 * @param MaxLength The maximum allowed string length.
-	 * @param bHasMinLength Whether a minimum length constraint is enforced.
-	 * @param MinLength The minimum allowed string length. Only enforced when bHasMinLength is true.
+	 * @param MinLength The minimum allowed string length.
 	 * @param Charset The set of allowed characters. An empty string applies no restriction.
 	 */
-	FTextSpace(int MaxLength, bool bHasMinLength, int MinLength, const FString& Charset)
-		: MaxLength(MaxLength), bHasMinLength(bHasMinLength), MinLength(MinLength), Charset(Charset) {};
+	FTextSpace(int MaxLength, int MinLength, const FString& Charset)
+		: MaxLength(MaxLength), MinLength(MinLength), Charset(Charset)
+	{
+		verifyf(MinLength >= 0, TEXT("FTextSpace MinLength (%d) must be non-negative"), MinLength);
+		verifyf(MinLength <= MaxLength, TEXT("FTextSpace MinLength (%d) must be <= MaxLength (%d)"), MinLength, MaxLength);
+	};
 
 	/**
 	 * @brief Copies the contents of another TextSpace into this one.

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Spaces/Space.h"
+#include "Spaces/SpaceVisitor.h"
+#include "Points/TextPoint.h"
+#include "TextSpace.generated.h"
+
+/**
+ * @struct FTextSpace
+ * @brief A struct representing a space of variable-length strings.
+ * 
+ * A text space represents a string whose length is bounded by [MinLength, MaxLength]
+ * and whose characters are optionally restricted to a fixed character set. This mirrors
+ * the gymnasium Text space and is commonly used for text-based observations or actions.
+ */
+USTRUCT(BlueprintType)
+struct SCHOLA_API FTextSpace : public FSpace
+{
+	GENERATED_BODY()
+public:
+
+	/**
+	 * @brief The maximum allowed length (inclusive) of strings in this space.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Maximum Length"))
+	int MaxLength = 0;
+
+	/**
+	 * @brief Whether a minimum length constraint is set for this space.
+	 * 
+	 * When false, MinLength is ignored and the effective minimum length is 0.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Has Minimum Length", InlineEditConditionToggle))
+	bool bHasMinLength = false;
+
+	/**
+	 * @brief The minimum allowed length (inclusive) of strings in this space.
+	 * 
+	 * Only enforced when bHasMinLength is true.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Minimum Length", EditCondition = "bHasMinLength"))
+	int MinLength = 0;
+
+	/**
+	 * @brief The set of characters allowed in strings in this space.
+	 * 
+	 * An empty charset means any character is permitted.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Character Set"))
+	FString Charset = TEXT("");
+
+	/**
+	 * @brief Constructs an empty TextSpace with MaxLength=0.
+	 */
+	FTextSpace();
+
+	/**
+	 * @brief Constructs a TextSpace with a specific maximum length.
+	 * @param MaxLength The maximum allowed string length.
+	 */
+	FTextSpace(int MaxLength) : MaxLength(MaxLength) {};
+
+	/**
+	 * @brief Copies the contents of another TextSpace into this one.
+	 * @param[in] Other The TextSpace to copy from.
+	 */
+	void Copy(const FTextSpace& Other);
+
+	/**
+	 * @brief Gets the number of dimensions in this space.
+	 * @return Always returns 1 for text spaces.
+	 */
+	int GetNumDimensions() const override;
+
+	/**
+	 * @brief Validates that a point conforms to this space.
+	 * @param[in] InPoint The point to validate.
+	 * @return Validation result indicating success or failure reason.
+	 */
+	ESpaceValidationResult Validate(const TInstancedStruct<FPoint>& InPoint) const override;
+
+	/**
+	 * @brief Gets the flattened size of this space.
+	 * @return The value of MaxLength.
+	 */
+	int GetFlattenedSize() const override;
+
+	/**
+	 * @brief Checks if this space is empty.
+	 * @return True if MaxLength is 0, false otherwise.
+	 */
+	bool IsEmpty() const override;
+
+	/**
+	 * @brief Accepts a mutable visitor for the visitor pattern.
+	 * @param[in,out] InVisitor The visitor to accept.
+	 */
+	virtual void Accept(SpaceVisitor& InVisitor)
+	{
+		InVisitor(*this);
+	}
+
+	/**
+	 * @brief Accepts a const visitor for the visitor pattern.
+	 * @param[in,out] InVisitor The visitor to accept.
+	 */
+	virtual void Accept(ConstSpaceVisitor& InVisitor) const
+	{
+		InVisitor(*this);
+	}
+};

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -46,7 +46,8 @@ public:
 	/**
 	 * @brief The set of characters allowed in strings in this space.
 	 * 
-	 * An empty charset means any character is permitted.
+	 * An empty charset applies no restriction in C++, but maps to Gymnasium's
+	 * default (alphanumeric) set when exchanged with Python.
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Definition", meta = (DisplayName = "Character Set"))
 	FString Charset = TEXT("");
@@ -61,6 +62,16 @@ public:
 	 * @param MaxLength The maximum allowed string length.
 	 */
 	FTextSpace(int MaxLength) : MaxLength(MaxLength) {};
+
+	/**
+	 * @brief Constructs a TextSpace from its length bounds and character set.
+	 * @param MaxLength The maximum allowed string length.
+	 * @param bHasMinLength Whether a minimum length constraint is enforced.
+	 * @param MinLength The minimum allowed string length. Only enforced when bHasMinLength is true.
+	 * @param Charset The set of allowed characters. An empty string applies no restriction.
+	 */
+	FTextSpace(int MaxLength, bool bHasMinLength, int MinLength, const FString& Charset)
+		: MaxLength(MaxLength), bHasMinLength(bHasMinLength), MinLength(MinLength), Charset(Charset) {};
 
 	/**
 	 * @brief Copies the contents of another TextSpace into this one.

--- a/Source/ScholaNNE/Public/Policies/NNEPolicy.h
+++ b/Source/ScholaNNE/Public/Policies/NNEPolicy.h
@@ -19,6 +19,9 @@
  * This policy class integrates Unreal Engine's Neural Network Engine (NNE) with the Schola
  * reinforcement learning framework, enabling trained neural network models to control agents.
  * Supports both CPU and GPU inference runtimes.
+ *
+ * @note Text spaces (FTextSpace) are not yet supported for NNE inference. Supported spaces are
+ * Box, Discrete, MultiDiscrete, MultiBinary, and Dict (and nested combinations thereof).
  */
 UCLASS(Blueprintable, BlueprintType, EditInlineNew, DefaultToInstanced)
 class SCHOLANNE_API UNNEPolicy : public UObject, public IPolicy

--- a/Source/ScholaProtobuf/Private/Points.pb.cc
+++ b/Source/ScholaProtobuf/Private/Points.pb.cc
@@ -33,6 +33,33 @@ namespace _pbi = ::google::protobuf::internal;
 namespace _fl = ::google::protobuf::internal::field_layout;
 namespace Schola {
 
+inline constexpr TextPoint::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        value_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()) {}
+
+template <typename>
+PROTOBUF_CONSTEXPR TextPoint::TextPoint(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(TextPoint_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct TextPointDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR TextPointDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~TextPointDefaultTypeInternal() {}
+  union {
+    TextPoint _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SCHOLAPROTOBUF_API
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 TextPointDefaultTypeInternal _TextPoint_default_instance_;
+
 inline constexpr MultiDiscretePoint::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : values_{},
@@ -240,8 +267,14 @@ const ::uint32_t
         1,
         0x000, // bitmap
         PROTOBUF_FIELD_OFFSET(::Schola::DictPoint, _impl_.values_),
+        0x081, // bitmap
+        PROTOBUF_FIELD_OFFSET(::Schola::TextPoint, _impl_._has_bits_),
+        4, // hasbit index offset
+        PROTOBUF_FIELD_OFFSET(::Schola::TextPoint, _impl_.value_),
+        0,
         0x004, // bitmap
         PROTOBUF_FIELD_OFFSET(::Schola::Point, _impl_._oneof_case_[0]),
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -258,7 +291,8 @@ static const ::_pbi::MigrationSchema
         {16, sizeof(::Schola::MultiBinaryPoint)},
         {18, sizeof(::Schola::DictPoint_ValuesEntry_DoNotUse)},
         {25, sizeof(::Schola::DictPoint)},
-        {27, sizeof(::Schola::Point)},
+        {27, sizeof(::Schola::TextPoint)},
+        {32, sizeof(::Schola::Point)},
 };
 static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::Schola::_BoxPoint_default_instance_._instance,
@@ -267,6 +301,7 @@ static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::Schola::_MultiBinaryPoint_default_instance_._instance,
     &::Schola::_DictPoint_ValuesEntry_DoNotUse_default_instance_._instance,
     &::Schola::_DictPoint_default_instance_._instance,
+    &::Schola::_TextPoint_default_instance_._instance,
     &::Schola::_Point_default_instance_._instance,
 };
 const char descriptor_table_protodef_Points_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
@@ -279,14 +314,15 @@ const char descriptor_table_protodef_Points_2eproto[] ABSL_ATTRIBUTE_SECTION_VAR
     "\n\006values\030\001 \003(\010\"x\n\tDictPoint\022-\n\006values\030\001 "
     "\003(\0132\035.Schola.DictPoint.ValuesEntry\032<\n\013Va"
     "luesEntry\022\013\n\003key\030\001 \001(\t\022\034\n\005value\030\002 \001(\0132\r."
-    "Schola.Point:\0028\001\"\205\002\n\005Point\022%\n\tbox_point\030"
-    "\001 \001(\0132\020.Schola.BoxPointH\000\022/\n\016discrete_po"
-    "int\030\002 \001(\0132\025.Schola.DiscretePointH\000\022:\n\024mu"
-    "lti_discrete_point\030\003 \001(\0132\032.Schola.MultiD"
-    "iscretePointH\000\0226\n\022multi_binary_point\030\004 \001"
-    "(\0132\030.Schola.MultiBinaryPointH\000\022\'\n\ndict_p"
-    "oint\030\005 \001(\0132\021.Schola.DictPointH\000B\007\n\005point"
-    "b\006proto3"
+    "Schola.Point:\0028\001\"\032\n\tTextPoint\022\r\n\005value\030\001"
+    " \001(\t\"\256\002\n\005Point\022%\n\tbox_point\030\001 \001(\0132\020.Scho"
+    "la.BoxPointH\000\022/\n\016discrete_point\030\002 \001(\0132\025."
+    "Schola.DiscretePointH\000\022:\n\024multi_discrete"
+    "_point\030\003 \001(\0132\032.Schola.MultiDiscretePoint"
+    "H\000\0226\n\022multi_binary_point\030\004 \001(\0132\030.Schola."
+    "MultiBinaryPointH\000\022\'\n\ndict_point\030\005 \001(\0132\021"
+    ".Schola.DictPointH\000\022\'\n\ntext_point\030\006 \001(\0132"
+    "\021.Schola.TextPointH\000B\007\n\005pointb\006proto3"
 };
 static const ::_pbi::DescriptorTable* PROTOBUF_NONNULL const
     descriptor_table_Points_2eproto_deps[1] = {
@@ -296,13 +332,13 @@ static ::absl::once_flag descriptor_table_Points_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_Points_2eproto = {
     false,
     false,
-    608,
+    677,
     descriptor_table_protodef_Points_2eproto,
     "Points.proto",
     &descriptor_table_Points_2eproto_once,
     descriptor_table_Points_2eproto_deps,
     1,
-    7,
+    8,
     schemas,
     file_default_instances,
     TableStruct_Points_2eproto::offsets,
@@ -1742,6 +1778,268 @@ void DictPoint::InternalSwap(DictPoint* PROTOBUF_RESTRICT PROTOBUF_NONNULL other
 }
 // ===================================================================
 
+class TextPoint::_Internal {
+ public:
+  using HasBits =
+      decltype(::std::declval<TextPoint>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(TextPoint, _impl_._has_bits_);
+};
+
+TextPoint::TextPoint(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, TextPoint_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:Schola.TextPoint)
+}
+PROTOBUF_NDEBUG_INLINE TextPoint::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+    const ::Schola::TextPoint& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        value_(arena, from.value_) {}
+
+TextPoint::TextPoint(
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena,
+    const TextPoint& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, TextPoint_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  TextPoint* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+
+  // @@protoc_insertion_point(copy_constructor:Schola.TextPoint)
+}
+PROTOBUF_NDEBUG_INLINE TextPoint::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+      : _cached_size_{0},
+        value_(arena) {}
+
+inline void TextPoint::SharedCtor(::_pb::Arena* PROTOBUF_NULLABLE arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+}
+TextPoint::~TextPoint() {
+  // @@protoc_insertion_point(destructor:Schola.TextPoint)
+  SharedDtor(*this);
+}
+inline void TextPoint::SharedDtor(MessageLite& self) {
+  TextPoint& this_ = static_cast<TextPoint&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.value_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* PROTOBUF_NONNULL TextPoint::PlacementNew_(
+    const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena) {
+  return ::new (mem) TextPoint(arena);
+}
+constexpr auto TextPoint::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(TextPoint),
+                                            alignof(TextPoint));
+}
+constexpr auto TextPoint::InternalGenerateClassData_() {
+  return ::google::protobuf::internal::ClassDataFull{
+      ::google::protobuf::internal::ClassData{
+          &_TextPoint_default_instance_._instance,
+          &_table_.header,
+          nullptr,  // OnDemandRegisterArenaDtor
+          nullptr,  // IsInitialized
+          &TextPoint::MergeImpl,
+          ::google::protobuf::Message::GetNewImpl<TextPoint>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+          &TextPoint::SharedDtor,
+          ::google::protobuf::Message::GetClearImpl<TextPoint>(), &TextPoint::ByteSizeLong,
+              &TextPoint::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          PROTOBUF_FIELD_OFFSET(TextPoint, _impl_._cached_size_),
+          false,
+      },
+      &TextPoint::kDescriptorMethods,
+      &descriptor_table_Points_2eproto,
+      nullptr,  // tracker
+  };
+}
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 const
+    ::google::protobuf::internal::ClassDataFull TextPoint_class_data_ =
+        TextPoint::InternalGenerateClassData_();
+
+PROTOBUF_ATTRIBUTE_WEAK const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL
+TextPoint::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&TextPoint_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(TextPoint_class_data_.tc_table);
+  return TextPoint_class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 30, 2>
+TextPoint::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(TextPoint, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    TextPoint_class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::Schola::TextPoint>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // string value = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(TextPoint, _impl_.value_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string value = 1;
+    {PROTOBUF_FIELD_OFFSET(TextPoint, _impl_.value_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+  }},
+  // no aux_entries
+  {{
+    "\20\5\0\0\0\0\0\0"
+    "Schola.TextPoint"
+    "value"
+  }},
+};
+PROTOBUF_NOINLINE void TextPoint::Clear() {
+// @@protoc_insertion_point(message_clear_start:Schola.TextPoint)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if ((cached_has_bits & 0x00000001u) != 0) {
+    _impl_.value_.ClearNonDefaultToEmpty();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::uint8_t* PROTOBUF_NONNULL TextPoint::_InternalSerialize(
+    const ::google::protobuf::MessageLite& base, ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) {
+  const TextPoint& this_ = static_cast<const TextPoint&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::uint8_t* PROTOBUF_NONNULL TextPoint::_InternalSerialize(
+    ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+  const TextPoint& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(serialize_to_array_start:Schola.TextPoint)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // string value = 1;
+  if ((this_._impl_._has_bits_[0] & 0x00000001u) != 0) {
+    if (!this_._internal_value().empty()) {
+      const ::std::string& _s = this_._internal_value();
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "Schola.TextPoint.value");
+      target = stream->WriteStringMaybeAliased(1, _s, target);
+    }
+  }
+
+  if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Schola.TextPoint)
+  return target;
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::size_t TextPoint::ByteSizeLong(const MessageLite& base) {
+  const TextPoint& this_ = static_cast<const TextPoint&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::size_t TextPoint::ByteSizeLong() const {
+  const TextPoint& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(message_byte_size_start:Schola.TextPoint)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void)cached_has_bits;
+
+   {
+    // string value = 1;
+    cached_has_bits = this_._impl_._has_bits_[0];
+    if ((cached_has_bits & 0x00000001u) != 0) {
+      if (!this_._internal_value().empty()) {
+        total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                        this_._internal_value());
+      }
+    }
+  }
+  return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                             &this_._impl_._cached_size_);
+}
+
+void TextPoint::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<TextPoint*>(&to_msg);
+  auto& from = static_cast<const TextPoint&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Schola.TextPoint)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if ((cached_has_bits & 0x00000001u) != 0) {
+    if (!from._internal_value().empty()) {
+      _this->_internal_set_value(from._internal_value());
+    } else {
+      if (_this->_impl_.value_.IsDefault()) {
+        _this->_internal_set_value("");
+      }
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void TextPoint::CopyFrom(const TextPoint& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Schola.TextPoint)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void TextPoint::InternalSwap(TextPoint* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
+  using ::std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.value_, &other->_impl_.value_, arena);
+}
+
+::google::protobuf::Metadata TextPoint::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
 class Point::_Internal {
  public:
   static constexpr ::int32_t kOneofCaseOffset =
@@ -1813,6 +2111,19 @@ void Point::set_allocated_dict_point(::Schola::DictPoint* PROTOBUF_NULLABLE dict
   }
   // @@protoc_insertion_point(field_set_allocated:Schola.Point.dict_point)
 }
+void Point::set_allocated_text_point(::Schola::TextPoint* PROTOBUF_NULLABLE text_point) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_point();
+  if (text_point) {
+    ::google::protobuf::Arena* submessage_arena = text_point->GetArena();
+    if (message_arena != submessage_arena) {
+      text_point = ::google::protobuf::internal::GetOwnedMessage(message_arena, text_point, submessage_arena);
+    }
+    set_has_text_point();
+    _impl_.point_.text_point_ = text_point;
+  }
+  // @@protoc_insertion_point(field_set_allocated:Schola.Point.text_point)
+}
 Point::Point(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, Point_class_data_.base()) {
@@ -1860,6 +2171,9 @@ Point::Point(
         break;
       case kDictPoint:
         _impl_.point_.dict_point_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.point_.dict_point_);
+        break;
+      case kTextPoint:
+        _impl_.point_.text_point_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.point_.text_point_);
         break;
   }
 
@@ -1933,6 +2247,14 @@ void Point::clear_point() {
       }
       break;
     }
+    case kTextPoint: {
+      if (GetArena() == nullptr) {
+        delete _impl_.point_.text_point_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.point_.text_point_);
+      }
+      break;
+    }
     case POINT_NOT_SET: {
       break;
     }
@@ -1984,17 +2306,17 @@ Point::GetClassData() const {
   return Point_class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<0, 5, 5, 0, 2>
+const ::_pbi::TcParseTable<0, 6, 6, 0, 2>
 Point::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    5, 0,  // max_field_number, fast_idx_mask
+    6, 0,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967264,  // skipmap
+    4294967232,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    5,  // num_field_entries
-    5,  // num_aux_entries
+    6,  // num_field_entries
+    6,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     Point_class_data_.base(),
     nullptr,  // post_loop_handler
@@ -2022,6 +2344,9 @@ Point::_table_ = {
     // .Schola.DictPoint dict_point = 5;
     {PROTOBUF_FIELD_OFFSET(Point, _impl_.point_.dict_point_), _Internal::kOneofCaseOffset + 0, 4,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .Schola.TextPoint text_point = 6;
+    {PROTOBUF_FIELD_OFFSET(Point, _impl_.point_.text_point_), _Internal::kOneofCaseOffset + 0, 5,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }},
   {{
       {::_pbi::TcParser::GetTable<::Schola::BoxPoint>()},
@@ -2029,6 +2354,7 @@ Point::_table_ = {
       {::_pbi::TcParser::GetTable<::Schola::MultiDiscretePoint>()},
       {::_pbi::TcParser::GetTable<::Schola::MultiBinaryPoint>()},
       {::_pbi::TcParser::GetTable<::Schola::DictPoint>()},
+      {::_pbi::TcParser::GetTable<::Schola::TextPoint>()},
   }},
   {{
   }},
@@ -2090,6 +2416,12 @@ PROTOBUF_NOINLINE void Point::Clear() {
           stream);
       break;
     }
+    case kTextPoint: {
+      target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+          6, *this_._impl_.point_.text_point_, this_._impl_.point_.text_point_->GetCachedSize(), target,
+          stream);
+      break;
+    }
     default:
       break;
   }
@@ -2145,6 +2477,12 @@ PROTOBUF_NOINLINE void Point::Clear() {
     case kDictPoint: {
       total_size += 1 +
                     ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.point_.dict_point_);
+      break;
+    }
+    // .Schola.TextPoint text_point = 6;
+    case kTextPoint: {
+      total_size += 1 +
+                    ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.point_.text_point_);
       break;
     }
     case POINT_NOT_SET: {
@@ -2212,6 +2550,14 @@ void Point::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::p
           _this->_impl_.point_.dict_point_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.point_.dict_point_);
         } else {
           _this->_impl_.point_.dict_point_->MergeFrom(*from._impl_.point_.dict_point_);
+        }
+        break;
+      }
+      case kTextPoint: {
+        if (oneof_needs_init) {
+          _this->_impl_.point_.text_point_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.point_.text_point_);
+        } else {
+          _this->_impl_.point_.text_point_->MergeFrom(*from._impl_.point_.text_point_);
         }
         break;
       }

--- a/Source/ScholaProtobuf/Private/Spaces.pb.cc
+++ b/Source/ScholaProtobuf/Private/Spaces.pb.cc
@@ -33,6 +33,35 @@ namespace _pbi = ::google::protobuf::internal;
 namespace _fl = ::google::protobuf::internal::field_layout;
 namespace Schola {
 
+inline constexpr TextSpace::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        charset_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        max_length_{0},
+        min_length_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR TextSpace::TextSpace(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(TextSpace_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct TextSpaceDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR TextSpaceDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~TextSpaceDefaultTypeInternal() {}
+  union {
+    TextSpace _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SCHOLAPROTOBUF_API
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 TextSpaceDefaultTypeInternal _TextSpace_default_instance_;
+
 inline constexpr MultiDiscreteSpace::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : high_{},
@@ -267,8 +296,18 @@ const ::uint32_t
         4, // hasbit index offset
         PROTOBUF_FIELD_OFFSET(::Schola::MultiBinarySpace, _impl_.shape_),
         0,
+        0x081, // bitmap
+        PROTOBUF_FIELD_OFFSET(::Schola::TextSpace, _impl_._has_bits_),
+        6, // hasbit index offset
+        PROTOBUF_FIELD_OFFSET(::Schola::TextSpace, _impl_.max_length_),
+        PROTOBUF_FIELD_OFFSET(::Schola::TextSpace, _impl_.min_length_),
+        PROTOBUF_FIELD_OFFSET(::Schola::TextSpace, _impl_.charset_),
+        1,
+        2,
+        0,
         0x004, // bitmap
         PROTOBUF_FIELD_OFFSET(::Schola::Space, _impl_._oneof_case_[0]),
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -293,9 +332,10 @@ static const ::_pbi::MigrationSchema
         {16, sizeof(::Schola::DiscreteSpace)},
         {21, sizeof(::Schola::MultiDiscreteSpace)},
         {23, sizeof(::Schola::MultiBinarySpace)},
-        {28, sizeof(::Schola::Space)},
-        {36, sizeof(::Schola::DictSpace_SpacesEntry_DoNotUse)},
-        {43, sizeof(::Schola::DictSpace)},
+        {28, sizeof(::Schola::TextSpace)},
+        {37, sizeof(::Schola::Space)},
+        {46, sizeof(::Schola::DictSpace_SpacesEntry_DoNotUse)},
+        {53, sizeof(::Schola::DictSpace)},
 };
 static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::Schola::_BoxSpace_BoxSpaceDimension_default_instance_._instance,
@@ -303,6 +343,7 @@ static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::Schola::_DiscreteSpace_default_instance_._instance,
     &::Schola::_MultiDiscreteSpace_default_instance_._instance,
     &::Schola::_MultiBinarySpace_default_instance_._instance,
+    &::Schola::_TextSpace_default_instance_._instance,
     &::Schola::_Space_default_instance_._instance,
     &::Schola::_DictSpace_SpacesEntry_DoNotUse_default_instance_._instance,
     &::Schola::_DictSpace_default_instance_._instance,
@@ -316,17 +357,21 @@ const char descriptor_table_protodef_Spaces_2eproto[] ABSL_ATTRIBUTE_SECTION_VAR
     "\032.\n\021BoxSpaceDimension\022\013\n\003low\030\001 \001(\002\022\014\n\004hi"
     "gh\030\002 \001(\002\"\035\n\rDiscreteSpace\022\014\n\004high\030\001 \001(\005\""
     "\"\n\022MultiDiscreteSpace\022\014\n\004high\030\001 \003(\005\"!\n\020M"
-    "ultiBinarySpace\022\r\n\005shape\030\001 \001(\005\"\205\002\n\005Space"
-    "\022%\n\tbox_space\030\001 \001(\0132\020.Schola.BoxSpaceH\000\022"
-    "/\n\016discrete_space\030\002 \001(\0132\025.Schola.Discret"
-    "eSpaceH\000\022:\n\024multi_discrete_space\030\003 \001(\0132\032"
-    ".Schola.MultiDiscreteSpaceH\000\0226\n\022multi_bi"
-    "nary_space\030\004 \001(\0132\030.Schola.MultiBinarySpa"
-    "ceH\000\022\'\n\ndict_space\030\005 \001(\0132\021.Schola.DictSp"
-    "aceH\000B\007\n\005space\"x\n\tDictSpace\022-\n\006spaces\030\001 "
-    "\003(\0132\035.Schola.DictSpace.SpacesEntry\032<\n\013Sp"
-    "acesEntry\022\013\n\003key\030\001 \001(\t\022\034\n\005value\030\002 \001(\0132\r."
-    "Schola.Space:\0028\001b\006proto3"
+    "ultiBinarySpace\022\r\n\005shape\030\001 \001(\005\"i\n\tTextSp"
+    "ace\022\022\n\nmax_length\030\001 \001(\005\022\027\n\nmin_length\030\002 "
+    "\001(\005H\000\210\001\001\022\024\n\007charset\030\003 \001(\tH\001\210\001\001B\r\n\013_min_l"
+    "engthB\n\n\010_charset\"\256\002\n\005Space\022%\n\tbox_space"
+    "\030\001 \001(\0132\020.Schola.BoxSpaceH\000\022/\n\016discrete_s"
+    "pace\030\002 \001(\0132\025.Schola.DiscreteSpaceH\000\022:\n\024m"
+    "ulti_discrete_space\030\003 \001(\0132\032.Schola.Multi"
+    "DiscreteSpaceH\000\0226\n\022multi_binary_space\030\004 "
+    "\001(\0132\030.Schola.MultiBinarySpaceH\000\022\'\n\ndict_"
+    "space\030\005 \001(\0132\021.Schola.DictSpaceH\000\022\'\n\ntext"
+    "_space\030\006 \001(\0132\021.Schola.TextSpaceH\000B\007\n\005spa"
+    "ce\"x\n\tDictSpace\022-\n\006spaces\030\001 \003(\0132\035.Schola"
+    ".DictSpace.SpacesEntry\032<\n\013SpacesEntry\022\013\n"
+    "\003key\030\001 \001(\t\022\034\n\005value\030\002 \001(\0132\r.Schola.Space"
+    ":\0028\001b\006proto3"
 };
 static const ::_pbi::DescriptorTable* PROTOBUF_NONNULL const
     descriptor_table_Spaces_2eproto_deps[1] = {
@@ -336,13 +381,13 @@ static ::absl::once_flag descriptor_table_Spaces_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_Spaces_2eproto = {
     false,
     false,
-    704,
+    852,
     descriptor_table_protodef_Spaces_2eproto,
     "Spaces.proto",
     &descriptor_table_Spaces_2eproto_once,
     descriptor_table_Spaces_2eproto_deps,
     1,
-    8,
+    9,
     schemas,
     file_default_instances,
     TableStruct_Spaces_2eproto::offsets,
@@ -1678,6 +1723,335 @@ void MultiBinarySpace::InternalSwap(MultiBinarySpace* PROTOBUF_RESTRICT PROTOBUF
 }
 // ===================================================================
 
+class TextSpace::_Internal {
+ public:
+  using HasBits =
+      decltype(::std::declval<TextSpace>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(TextSpace, _impl_._has_bits_);
+};
+
+TextSpace::TextSpace(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, TextSpace_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:Schola.TextSpace)
+}
+PROTOBUF_NDEBUG_INLINE TextSpace::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+    const ::Schola::TextSpace& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        charset_(arena, from.charset_) {}
+
+TextSpace::TextSpace(
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena,
+    const TextSpace& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, TextSpace_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  TextSpace* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::memcpy(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, max_length_),
+           reinterpret_cast<const char *>(&from._impl_) +
+               offsetof(Impl_, max_length_),
+           offsetof(Impl_, min_length_) -
+               offsetof(Impl_, max_length_) +
+               sizeof(Impl_::min_length_));
+
+  // @@protoc_insertion_point(copy_constructor:Schola.TextSpace)
+}
+PROTOBUF_NDEBUG_INLINE TextSpace::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+      : _cached_size_{0},
+        charset_(arena) {}
+
+inline void TextSpace::SharedCtor(::_pb::Arena* PROTOBUF_NULLABLE arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, max_length_),
+           0,
+           offsetof(Impl_, min_length_) -
+               offsetof(Impl_, max_length_) +
+               sizeof(Impl_::min_length_));
+}
+TextSpace::~TextSpace() {
+  // @@protoc_insertion_point(destructor:Schola.TextSpace)
+  SharedDtor(*this);
+}
+inline void TextSpace::SharedDtor(MessageLite& self) {
+  TextSpace& this_ = static_cast<TextSpace&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.charset_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* PROTOBUF_NONNULL TextSpace::PlacementNew_(
+    const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena) {
+  return ::new (mem) TextSpace(arena);
+}
+constexpr auto TextSpace::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(TextSpace),
+                                            alignof(TextSpace));
+}
+constexpr auto TextSpace::InternalGenerateClassData_() {
+  return ::google::protobuf::internal::ClassDataFull{
+      ::google::protobuf::internal::ClassData{
+          &_TextSpace_default_instance_._instance,
+          &_table_.header,
+          nullptr,  // OnDemandRegisterArenaDtor
+          nullptr,  // IsInitialized
+          &TextSpace::MergeImpl,
+          ::google::protobuf::Message::GetNewImpl<TextSpace>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+          &TextSpace::SharedDtor,
+          ::google::protobuf::Message::GetClearImpl<TextSpace>(), &TextSpace::ByteSizeLong,
+              &TextSpace::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          PROTOBUF_FIELD_OFFSET(TextSpace, _impl_._cached_size_),
+          false,
+      },
+      &TextSpace::kDescriptorMethods,
+      &descriptor_table_Spaces_2eproto,
+      nullptr,  // tracker
+  };
+}
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 const
+    ::google::protobuf::internal::ClassDataFull TextSpace_class_data_ =
+        TextSpace::InternalGenerateClassData_();
+
+PROTOBUF_ATTRIBUTE_WEAK const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL
+TextSpace::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&TextSpace_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(TextSpace_class_data_.tc_table);
+  return TextSpace_class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 0, 32, 2>
+TextSpace::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(TextSpace, _impl_._has_bits_),
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    TextSpace_class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::Schola::TextSpace>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // int32 max_length = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(TextSpace, _impl_.max_length_), 1>(),
+     {8, 1, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.max_length_)}},
+    // optional int32 min_length = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(TextSpace, _impl_.min_length_), 2>(),
+     {16, 2, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.min_length_)}},
+    // optional string charset = 3;
+    {::_pbi::TcParser::FastUS1,
+     {26, 0, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.charset_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 max_length = 1;
+    {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.max_length_), _Internal::kHasBitsOffset + 1, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kInt32)},
+    // optional int32 min_length = 2;
+    {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.min_length_), _Internal::kHasBitsOffset + 2, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kInt32)},
+    // optional string charset = 3;
+    {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.charset_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+  }},
+  // no aux_entries
+  {{
+    "\20\0\0\7\0\0\0\0"
+    "Schola.TextSpace"
+    "charset"
+  }},
+};
+PROTOBUF_NOINLINE void TextSpace::Clear() {
+// @@protoc_insertion_point(message_clear_start:Schola.TextSpace)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if ((cached_has_bits & 0x00000001u) != 0) {
+    _impl_.charset_.ClearNonDefaultToEmpty();
+  }
+  if ((cached_has_bits & 0x00000006u) != 0) {
+    ::memset(&_impl_.max_length_, 0, static_cast<::size_t>(
+        reinterpret_cast<char*>(&_impl_.min_length_) -
+        reinterpret_cast<char*>(&_impl_.max_length_)) + sizeof(_impl_.min_length_));
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::uint8_t* PROTOBUF_NONNULL TextSpace::_InternalSerialize(
+    const ::google::protobuf::MessageLite& base, ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) {
+  const TextSpace& this_ = static_cast<const TextSpace&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::uint8_t* PROTOBUF_NONNULL TextSpace::_InternalSerialize(
+    ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+  const TextSpace& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(serialize_to_array_start:Schola.TextSpace)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // int32 max_length = 1;
+  if ((this_._impl_._has_bits_[0] & 0x00000002u) != 0) {
+    if (this_._internal_max_length() != 0) {
+      target =
+          ::google::protobuf::internal::WireFormatLite::WriteInt32ToArrayWithField<1>(
+              stream, this_._internal_max_length(), target);
+    }
+  }
+
+  cached_has_bits = this_._impl_._has_bits_[0];
+  // optional int32 min_length = 2;
+  if ((cached_has_bits & 0x00000004u) != 0) {
+    target =
+        ::google::protobuf::internal::WireFormatLite::WriteInt32ToArrayWithField<2>(
+            stream, this_._internal_min_length(), target);
+  }
+
+  // optional string charset = 3;
+  if ((cached_has_bits & 0x00000001u) != 0) {
+    const ::std::string& _s = this_._internal_charset();
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "Schola.TextSpace.charset");
+    target = stream->WriteStringMaybeAliased(3, _s, target);
+  }
+
+  if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Schola.TextSpace)
+  return target;
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::size_t TextSpace::ByteSizeLong(const MessageLite& base) {
+  const TextSpace& this_ = static_cast<const TextSpace&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::size_t TextSpace::ByteSizeLong() const {
+  const TextSpace& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(message_byte_size_start:Schola.TextSpace)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void)cached_has_bits;
+
+  ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+  cached_has_bits = this_._impl_._has_bits_[0];
+  if ((cached_has_bits & 0x00000007u) != 0) {
+    // optional string charset = 3;
+    if ((cached_has_bits & 0x00000001u) != 0) {
+      total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                      this_._internal_charset());
+    }
+    // int32 max_length = 1;
+    if ((cached_has_bits & 0x00000002u) != 0) {
+      if (this_._internal_max_length() != 0) {
+        total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+            this_._internal_max_length());
+      }
+    }
+    // optional int32 min_length = 2;
+    if ((cached_has_bits & 0x00000004u) != 0) {
+      total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+          this_._internal_min_length());
+    }
+  }
+  return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                             &this_._impl_._cached_size_);
+}
+
+void TextSpace::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<TextSpace*>(&to_msg);
+  auto& from = static_cast<const TextSpace&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Schola.TextSpace)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if ((cached_has_bits & 0x00000007u) != 0) {
+    if ((cached_has_bits & 0x00000001u) != 0) {
+      _this->_internal_set_charset(from._internal_charset());
+    }
+    if ((cached_has_bits & 0x00000002u) != 0) {
+      if (from._internal_max_length() != 0) {
+        _this->_impl_.max_length_ = from._impl_.max_length_;
+      }
+    }
+    if ((cached_has_bits & 0x00000004u) != 0) {
+      _this->_impl_.min_length_ = from._impl_.min_length_;
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void TextSpace::CopyFrom(const TextSpace& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Schola.TextSpace)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void TextSpace::InternalSwap(TextSpace* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
+  using ::std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.charset_, &other->_impl_.charset_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.min_length_)
+      + sizeof(TextSpace::_impl_.min_length_)
+      - PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.max_length_)>(
+          reinterpret_cast<char*>(&_impl_.max_length_),
+          reinterpret_cast<char*>(&other->_impl_.max_length_));
+}
+
+::google::protobuf::Metadata TextSpace::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
 class Space::_Internal {
  public:
   static constexpr ::int32_t kOneofCaseOffset =
@@ -1749,6 +2123,19 @@ void Space::set_allocated_dict_space(::Schola::DictSpace* PROTOBUF_NULLABLE dict
   }
   // @@protoc_insertion_point(field_set_allocated:Schola.Space.dict_space)
 }
+void Space::set_allocated_text_space(::Schola::TextSpace* PROTOBUF_NULLABLE text_space) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_space();
+  if (text_space) {
+    ::google::protobuf::Arena* submessage_arena = text_space->GetArena();
+    if (message_arena != submessage_arena) {
+      text_space = ::google::protobuf::internal::GetOwnedMessage(message_arena, text_space, submessage_arena);
+    }
+    set_has_text_space();
+    _impl_.space_.text_space_ = text_space;
+  }
+  // @@protoc_insertion_point(field_set_allocated:Schola.Space.text_space)
+}
 Space::Space(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, Space_class_data_.base()) {
@@ -1796,6 +2183,9 @@ Space::Space(
         break;
       case kDictSpace:
         _impl_.space_.dict_space_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.space_.dict_space_);
+        break;
+      case kTextSpace:
+        _impl_.space_.text_space_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.space_.text_space_);
         break;
   }
 
@@ -1869,6 +2259,14 @@ void Space::clear_space() {
       }
       break;
     }
+    case kTextSpace: {
+      if (GetArena() == nullptr) {
+        delete _impl_.space_.text_space_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.space_.text_space_);
+      }
+      break;
+    }
     case SPACE_NOT_SET: {
       break;
     }
@@ -1920,17 +2318,17 @@ Space::GetClassData() const {
   return Space_class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<0, 5, 5, 0, 2>
+const ::_pbi::TcParseTable<0, 6, 6, 0, 2>
 Space::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    5, 0,  // max_field_number, fast_idx_mask
+    6, 0,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967264,  // skipmap
+    4294967232,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    5,  // num_field_entries
-    5,  // num_aux_entries
+    6,  // num_field_entries
+    6,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     Space_class_data_.base(),
     nullptr,  // post_loop_handler
@@ -1958,6 +2356,9 @@ Space::_table_ = {
     // .Schola.DictSpace dict_space = 5;
     {PROTOBUF_FIELD_OFFSET(Space, _impl_.space_.dict_space_), _Internal::kOneofCaseOffset + 0, 4,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .Schola.TextSpace text_space = 6;
+    {PROTOBUF_FIELD_OFFSET(Space, _impl_.space_.text_space_), _Internal::kOneofCaseOffset + 0, 5,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }},
   {{
       {::_pbi::TcParser::GetTable<::Schola::BoxSpace>()},
@@ -1965,6 +2366,7 @@ Space::_table_ = {
       {::_pbi::TcParser::GetTable<::Schola::MultiDiscreteSpace>()},
       {::_pbi::TcParser::GetTable<::Schola::MultiBinarySpace>()},
       {::_pbi::TcParser::GetTable<::Schola::DictSpace>()},
+      {::_pbi::TcParser::GetTable<::Schola::TextSpace>()},
   }},
   {{
   }},
@@ -2026,6 +2428,12 @@ PROTOBUF_NOINLINE void Space::Clear() {
           stream);
       break;
     }
+    case kTextSpace: {
+      target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+          6, *this_._impl_.space_.text_space_, this_._impl_.space_.text_space_->GetCachedSize(), target,
+          stream);
+      break;
+    }
     default:
       break;
   }
@@ -2081,6 +2489,12 @@ PROTOBUF_NOINLINE void Space::Clear() {
     case kDictSpace: {
       total_size += 1 +
                     ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.space_.dict_space_);
+      break;
+    }
+    // .Schola.TextSpace text_space = 6;
+    case kTextSpace: {
+      total_size += 1 +
+                    ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.space_.text_space_);
       break;
     }
     case SPACE_NOT_SET: {
@@ -2148,6 +2562,14 @@ void Space::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::p
           _this->_impl_.space_.dict_space_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.space_.dict_space_);
         } else {
           _this->_impl_.space_.dict_space_->MergeFrom(*from._impl_.space_.dict_space_);
+        }
+        break;
+      }
+      case kTextSpace: {
+        if (oneof_needs_init) {
+          _this->_impl_.space_.text_space_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.space_.text_space_);
+        } else {
+          _this->_impl_.space_.text_space_->MergeFrom(*from._impl_.space_.text_space_);
         }
         break;
       }

--- a/Source/ScholaProtobuf/Private/Spaces.pb.cc
+++ b/Source/ScholaProtobuf/Private/Spaces.pb.cc
@@ -357,21 +357,20 @@ const char descriptor_table_protodef_Spaces_2eproto[] ABSL_ATTRIBUTE_SECTION_VAR
     "\032.\n\021BoxSpaceDimension\022\013\n\003low\030\001 \001(\002\022\014\n\004hi"
     "gh\030\002 \001(\002\"\035\n\rDiscreteSpace\022\014\n\004high\030\001 \001(\005\""
     "\"\n\022MultiDiscreteSpace\022\014\n\004high\030\001 \003(\005\"!\n\020M"
-    "ultiBinarySpace\022\r\n\005shape\030\001 \001(\005\"i\n\tTextSp"
-    "ace\022\022\n\nmax_length\030\001 \001(\005\022\027\n\nmin_length\030\002 "
-    "\001(\005H\000\210\001\001\022\024\n\007charset\030\003 \001(\tH\001\210\001\001B\r\n\013_min_l"
-    "engthB\n\n\010_charset\"\256\002\n\005Space\022%\n\tbox_space"
-    "\030\001 \001(\0132\020.Schola.BoxSpaceH\000\022/\n\016discrete_s"
-    "pace\030\002 \001(\0132\025.Schola.DiscreteSpaceH\000\022:\n\024m"
-    "ulti_discrete_space\030\003 \001(\0132\032.Schola.Multi"
-    "DiscreteSpaceH\000\0226\n\022multi_binary_space\030\004 "
-    "\001(\0132\030.Schola.MultiBinarySpaceH\000\022\'\n\ndict_"
-    "space\030\005 \001(\0132\021.Schola.DictSpaceH\000\022\'\n\ntext"
-    "_space\030\006 \001(\0132\021.Schola.TextSpaceH\000B\007\n\005spa"
-    "ce\"x\n\tDictSpace\022-\n\006spaces\030\001 \003(\0132\035.Schola"
-    ".DictSpace.SpacesEntry\032<\n\013SpacesEntry\022\013\n"
-    "\003key\030\001 \001(\t\022\034\n\005value\030\002 \001(\0132\r.Schola.Space"
-    ":\0028\001b\006proto3"
+    "ultiBinarySpace\022\r\n\005shape\030\001 \001(\005\"D\n\tTextSp"
+    "ace\022\022\n\nmax_length\030\001 \001(\005\022\022\n\nmin_length\030\002 "
+    "\001(\005\022\017\n\007charset\030\003 \001(\t\"\256\002\n\005Space\022%\n\tbox_sp"
+    "ace\030\001 \001(\0132\020.Schola.BoxSpaceH\000\022/\n\016discret"
+    "e_space\030\002 \001(\0132\025.Schola.DiscreteSpaceH\000\022:"
+    "\n\024multi_discrete_space\030\003 \001(\0132\032.Schola.Mu"
+    "ltiDiscreteSpaceH\000\0226\n\022multi_binary_space"
+    "\030\004 \001(\0132\030.Schola.MultiBinarySpaceH\000\022\'\n\ndi"
+    "ct_space\030\005 \001(\0132\021.Schola.DictSpaceH\000\022\'\n\nt"
+    "ext_space\030\006 \001(\0132\021.Schola.TextSpaceH\000B\007\n\005"
+    "space\"x\n\tDictSpace\022-\n\006spaces\030\001 \003(\0132\035.Sch"
+    "ola.DictSpace.SpacesEntry\032<\n\013SpacesEntry"
+    "\022\013\n\003key\030\001 \001(\t\022\034\n\005value\030\002 \001(\0132\r.Schola.Sp"
+    "ace:\0028\001b\006proto3"
 };
 static const ::_pbi::DescriptorTable* PROTOBUF_NONNULL const
     descriptor_table_Spaces_2eproto_deps[1] = {
@@ -381,7 +380,7 @@ static ::absl::once_flag descriptor_table_Spaces_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_Spaces_2eproto = {
     false,
     false,
-    852,
+    815,
     descriptor_table_protodef_Spaces_2eproto,
     "Spaces.proto",
     &descriptor_table_Spaces_2eproto_once,
@@ -1864,10 +1863,10 @@ TextSpace::_table_ = {
     // int32 max_length = 1;
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(TextSpace, _impl_.max_length_), 1>(),
      {8, 1, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.max_length_)}},
-    // optional int32 min_length = 2;
+    // int32 min_length = 2;
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(TextSpace, _impl_.min_length_), 2>(),
      {16, 2, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.min_length_)}},
-    // optional string charset = 3;
+    // string charset = 3;
     {::_pbi::TcParser::FastUS1,
      {26, 0, 0, PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.charset_)}},
   }}, {{
@@ -1876,10 +1875,10 @@ TextSpace::_table_ = {
     // int32 max_length = 1;
     {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.max_length_), _Internal::kHasBitsOffset + 1, 0,
     (0 | ::_fl::kFcOptional | ::_fl::kInt32)},
-    // optional int32 min_length = 2;
+    // int32 min_length = 2;
     {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.min_length_), _Internal::kHasBitsOffset + 2, 0,
     (0 | ::_fl::kFcOptional | ::_fl::kInt32)},
-    // optional string charset = 3;
+    // string charset = 3;
     {PROTOBUF_FIELD_OFFSET(TextSpace, _impl_.charset_), _Internal::kHasBitsOffset + 0, 0,
     (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
   }},
@@ -1934,20 +1933,23 @@ PROTOBUF_NOINLINE void TextSpace::Clear() {
     }
   }
 
-  cached_has_bits = this_._impl_._has_bits_[0];
-  // optional int32 min_length = 2;
-  if ((cached_has_bits & 0x00000004u) != 0) {
-    target =
-        ::google::protobuf::internal::WireFormatLite::WriteInt32ToArrayWithField<2>(
-            stream, this_._internal_min_length(), target);
+  // int32 min_length = 2;
+  if ((this_._impl_._has_bits_[0] & 0x00000004u) != 0) {
+    if (this_._internal_min_length() != 0) {
+      target =
+          ::google::protobuf::internal::WireFormatLite::WriteInt32ToArrayWithField<2>(
+              stream, this_._internal_min_length(), target);
+    }
   }
 
-  // optional string charset = 3;
-  if ((cached_has_bits & 0x00000001u) != 0) {
-    const ::std::string& _s = this_._internal_charset();
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-        _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "Schola.TextSpace.charset");
-    target = stream->WriteStringMaybeAliased(3, _s, target);
+  // string charset = 3;
+  if ((this_._impl_._has_bits_[0] & 0x00000001u) != 0) {
+    if (!this_._internal_charset().empty()) {
+      const ::std::string& _s = this_._internal_charset();
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "Schola.TextSpace.charset");
+      target = stream->WriteStringMaybeAliased(3, _s, target);
+    }
   }
 
   if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -1976,10 +1978,12 @@ PROTOBUF_NOINLINE void TextSpace::Clear() {
   ::_pbi::Prefetch5LinesFrom7Lines(&this_);
   cached_has_bits = this_._impl_._has_bits_[0];
   if ((cached_has_bits & 0x00000007u) != 0) {
-    // optional string charset = 3;
+    // string charset = 3;
     if ((cached_has_bits & 0x00000001u) != 0) {
-      total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
-                                      this_._internal_charset());
+      if (!this_._internal_charset().empty()) {
+        total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                        this_._internal_charset());
+      }
     }
     // int32 max_length = 1;
     if ((cached_has_bits & 0x00000002u) != 0) {
@@ -1988,10 +1992,12 @@ PROTOBUF_NOINLINE void TextSpace::Clear() {
             this_._internal_max_length());
       }
     }
-    // optional int32 min_length = 2;
+    // int32 min_length = 2;
     if ((cached_has_bits & 0x00000004u) != 0) {
-      total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
-          this_._internal_min_length());
+      if (this_._internal_min_length() != 0) {
+        total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+            this_._internal_min_length());
+      }
     }
   }
   return this_.MaybeComputeUnknownFieldsSize(total_size,
@@ -2009,7 +2015,13 @@ void TextSpace::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::googl
   cached_has_bits = from._impl_._has_bits_[0];
   if ((cached_has_bits & 0x00000007u) != 0) {
     if ((cached_has_bits & 0x00000001u) != 0) {
-      _this->_internal_set_charset(from._internal_charset());
+      if (!from._internal_charset().empty()) {
+        _this->_internal_set_charset(from._internal_charset());
+      } else {
+        if (_this->_impl_.charset_.IsDefault()) {
+          _this->_internal_set_charset("");
+        }
+      }
     }
     if ((cached_has_bits & 0x00000002u) != 0) {
       if (from._internal_max_length() != 0) {
@@ -2017,7 +2029,9 @@ void TextSpace::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::googl
       }
     }
     if ((cached_has_bits & 0x00000004u) != 0) {
-      _this->_impl_.min_length_ = from._impl_.min_length_;
+      if (from._internal_min_length() != 0) {
+        _this->_impl_.min_length_ = from._impl_.min_length_;
+      }
     }
   }
   _this->_impl_._has_bits_[0] |= cached_has_bits;

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/PointDeserializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/PointDeserializationTest.cpp
@@ -10,6 +10,7 @@
 #include "Points/DiscretePoint.h"
 #include "Points/MultiDiscretePoint.h"
 #include "Points/BoxPoint.h"
+#include "Points/TextPoint.h"
 
 #include <string>
 
@@ -97,6 +98,25 @@ bool FProtobufBoxPointDeserializationTest::RunTest(const FString& Parameters)
 		TestTrue(TEXT("Box[0] approx 0.1"), FMath::IsNearlyEqual(Box->Values[0], 0.1f));
 		TestTrue(TEXT("Box[1] approx 0.2"), FMath::IsNearlyEqual(Box->Values[1], 0.2f));
 		TestTrue(TEXT("Box[2] approx 0.3"), FMath::IsNearlyEqual(Box->Values[2], 0.3f));
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextPointDeserializationTest, "Schola.Protobuf.Deserialization.Points.Text", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextPointDeserializationTest::RunTest(const FString& Parameters)
+{
+	Schola::Point InProto;
+	InProto.mutable_text_point()->set_value("hello world");
+
+	TInstancedStruct<FPoint> Out;
+	ProtobufDeserializer::FromProto(InProto, Out);
+
+	const FTextPoint* Text = Out.GetPtr<FTextPoint>();
+	TestTrue(TEXT("Text point deserialized as text_point"), Text != nullptr);
+	if (Text)
+	{
+		TestEqual(TEXT("Text value matches"), Text->Value, FString(TEXT("hello world")));
 	}
 
 	return true;

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/PointSerializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/PointSerializationTest.cpp
@@ -10,6 +10,7 @@
 #include "Points/DiscretePoint.h"
 #include "Points/MultiDiscretePoint.h"
 #include "Points/BoxPoint.h"
+#include "Points/TextPoint.h"
 
 #include <string>
 
@@ -103,6 +104,24 @@ bool FProtobufBoxPointSerializationTest::RunTest(const FString& Parameters)
 		TestTrue(TEXT("Box[2] approx 0.3"), FMath::IsNearlyEqual((float)Repeated.Get(2), 0.3f));
 		TestTrue(TEXT("Box Shape Has 2 Dimensions"), OutProto.box_point().shape().size() == 2);
 		TestEqual(TEXT("Box Shape First Dimension is 2"), OutProto.box_point().shape().Get(0), 2);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextPointSerializationTest, "Schola.Protobuf.Serialization.Points.Text", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextPointSerializationTest::RunTest(const FString& Parameters)
+{
+	TInstancedStruct<FPoint> Inst;
+	Inst.InitializeAs<FTextPoint>(FString(TEXT("hello world")));
+
+	Schola::Point OutProto;
+	ProtobufSerializer::ToProto(Inst, &OutProto);
+
+	TestTrue(TEXT("Text point serialized as text_point"), OutProto.has_text_point());
+	if (OutProto.has_text_point())
+	{
+		TestEqual(TEXT("Text value matches"), FString(UTF8_TO_TCHAR(OutProto.text_point().value().c_str())), FString(TEXT("hello world")));
 	}
 
 	return true;

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
@@ -145,7 +145,8 @@ bool FProtobufTextSpaceDeserializationTest::RunTest(const FString& Parameters)
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalDeserializationTest, "Schola.Protobuf.Deserialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FProtobufTextSpaceMinimalDeserializationTest::RunTest(const FString& Parameters)
 {
-	// Only max_length set: min_length should fall back to the default of 1 and charset stay empty.
+	// Only max_length set: min_length is copied verbatim (proto default 0) and an empty
+	// charset stays empty (the empty set; only the empty string is a valid point).
 	Schola::Space InProto;
 	InProto.mutable_text_space()->set_max_length(10);
 
@@ -157,7 +158,7 @@ bool FProtobufTextSpaceMinimalDeserializationTest::RunTest(const FString& Parame
 	if (Space)
 	{
 		TestEqual(TEXT("TextSpace.MaxLength == 10"), Space->MaxLength, 10);
-		TestEqual(TEXT("TextSpace.MinLength == 1"), Space->MinLength, 1);
+		TestEqual(TEXT("TextSpace.MinLength == 0"), Space->MinLength, 0);
 		TestTrue(TEXT("TextSpace.Charset empty"), Space->Charset.IsEmpty());
 	}
 

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
@@ -10,6 +10,7 @@
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
 #include "Spaces/BoxSpaceDimension.h"
+#include "Spaces/TextSpace.h"
 
 #include <string>
 
@@ -112,6 +113,53 @@ bool FProtobufBoxSpaceDeserializationTest::RunTest(const FString& Parameters)
 		{
 			TestEqual(TEXT("BoxSpace.shape[0] == 2"), Space->Shape[0], 2);
 		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceDeserializationTest, "Schola.Protobuf.Deserialization.Spaces.Text", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextSpaceDeserializationTest::RunTest(const FString& Parameters)
+{
+	Schola::Space InProto;
+	auto* TextProto = InProto.mutable_text_space();
+	TextProto->set_max_length(32);
+	TextProto->set_min_length(4);
+	TextProto->set_charset("abc");
+
+	TInstancedStruct<FSpace> Out;
+	ProtobufDeserializer::FromProto(InProto, Out);
+
+	const FTextSpace* Space = Out.GetPtr<FTextSpace>();
+	TestTrue(TEXT("Text space deserialized as text_space"), Space != nullptr);
+	if (Space)
+	{
+		TestEqual(TEXT("TextSpace.MaxLength == 32"), Space->MaxLength, 32);
+		TestTrue(TEXT("TextSpace.bHasMinLength true"), Space->bHasMinLength);
+		TestEqual(TEXT("TextSpace.MinLength == 4"), Space->MinLength, 4);
+		TestEqual(TEXT("TextSpace.Charset == abc"), Space->Charset, FString(TEXT("abc")));
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalDeserializationTest, "Schola.Protobuf.Deserialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextSpaceMinimalDeserializationTest::RunTest(const FString& Parameters)
+{
+	// Only max_length set: min length flag should be false and charset empty.
+	Schola::Space InProto;
+	InProto.mutable_text_space()->set_max_length(10);
+
+	TInstancedStruct<FSpace> Out;
+	ProtobufDeserializer::FromProto(InProto, Out);
+
+	const FTextSpace* Space = Out.GetPtr<FTextSpace>();
+	TestTrue(TEXT("Text space deserialized as text_space"), Space != nullptr);
+	if (Space)
+	{
+		TestEqual(TEXT("TextSpace.MaxLength == 10"), Space->MaxLength, 10);
+		TestFalse(TEXT("TextSpace.bHasMinLength false"), Space->bHasMinLength);
+		TestTrue(TEXT("TextSpace.Charset empty"), Space->Charset.IsEmpty());
 	}
 
 	return true;

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceDeserializationTest.cpp
@@ -135,7 +135,6 @@ bool FProtobufTextSpaceDeserializationTest::RunTest(const FString& Parameters)
 	if (Space)
 	{
 		TestEqual(TEXT("TextSpace.MaxLength == 32"), Space->MaxLength, 32);
-		TestTrue(TEXT("TextSpace.bHasMinLength true"), Space->bHasMinLength);
 		TestEqual(TEXT("TextSpace.MinLength == 4"), Space->MinLength, 4);
 		TestEqual(TEXT("TextSpace.Charset == abc"), Space->Charset, FString(TEXT("abc")));
 	}
@@ -146,7 +145,7 @@ bool FProtobufTextSpaceDeserializationTest::RunTest(const FString& Parameters)
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalDeserializationTest, "Schola.Protobuf.Deserialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FProtobufTextSpaceMinimalDeserializationTest::RunTest(const FString& Parameters)
 {
-	// Only max_length set: min length flag should be false and charset empty.
+	// Only max_length set: min_length should fall back to the default of 1 and charset stay empty.
 	Schola::Space InProto;
 	InProto.mutable_text_space()->set_max_length(10);
 
@@ -158,7 +157,7 @@ bool FProtobufTextSpaceMinimalDeserializationTest::RunTest(const FString& Parame
 	if (Space)
 	{
 		TestEqual(TEXT("TextSpace.MaxLength == 10"), Space->MaxLength, 10);
-		TestFalse(TEXT("TextSpace.bHasMinLength false"), Space->bHasMinLength);
+		TestEqual(TEXT("TextSpace.MinLength == 1"), Space->MinLength, 1);
 		TestTrue(TEXT("TextSpace.Charset empty"), Space->Charset.IsEmpty());
 	}
 

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
@@ -130,9 +130,7 @@ bool FProtobufTextSpaceSerializationTest::RunTest(const FString& Parameters)
 	if (OutProto.has_text_space())
 	{
 		TestEqual(TEXT("TextSpace.max_length == 32"), OutProto.text_space().max_length(), 32);
-		TestTrue(TEXT("TextSpace has min_length set"), OutProto.text_space().has_min_length());
 		TestEqual(TEXT("TextSpace.min_length == 4"), OutProto.text_space().min_length(), 4);
-		TestTrue(TEXT("TextSpace has charset set"), OutProto.text_space().has_charset());
 		TestEqual(TEXT("TextSpace.charset == abc"), FString(UTF8_TO_TCHAR(OutProto.text_space().charset().c_str())), FString(TEXT("abc")));
 	}
 
@@ -142,12 +140,14 @@ bool FProtobufTextSpaceSerializationTest::RunTest(const FString& Parameters)
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalSerializationTest, "Schola.Protobuf.Serialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FProtobufTextSpaceMinimalSerializationTest::RunTest(const FString& Parameters)
 {
-	// min_length is always serialized. A default-constructed FTextSpace has MinLength 0
-	// (so an empty space stays coherent); charset stays unset when empty.
+	// All fields are serialized verbatim. An empty Charset (the empty set) is sent as an
+	// empty string; min_length is sent as-is (0 here so an empty space stays coherent).
 	TInstancedStruct<FSpace> Inst;
 	Inst.InitializeAs<FTextSpace>();
 	FTextSpace* Space = Inst.GetMutablePtr<FTextSpace>();
 	Space->MaxLength = 10;
+	Space->MinLength = 0;
+	Space->Charset = TEXT("");
 
 	Schola::Space OutProto;
 	ProtobufSerializer::ToProto(Inst, &OutProto);
@@ -156,9 +156,8 @@ bool FProtobufTextSpaceMinimalSerializationTest::RunTest(const FString& Paramete
 	if (OutProto.has_text_space())
 	{
 		TestEqual(TEXT("TextSpace.max_length == 10"), OutProto.text_space().max_length(), 10);
-		TestTrue(TEXT("TextSpace has min_length set"), OutProto.text_space().has_min_length());
 		TestEqual(TEXT("TextSpace.min_length == 0"), OutProto.text_space().min_length(), 0);
-		TestFalse(TEXT("TextSpace charset unset"), OutProto.text_space().has_charset());
+		TestTrue(TEXT("TextSpace charset is empty"), OutProto.text_space().charset().empty());
 	}
 
 	return true;

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
@@ -120,7 +120,6 @@ bool FProtobufTextSpaceSerializationTest::RunTest(const FString& Parameters)
 	Inst.InitializeAs<FTextSpace>();
 	FTextSpace* Space = Inst.GetMutablePtr<FTextSpace>();
 	Space->MaxLength = 32;
-	Space->bHasMinLength = true;
 	Space->MinLength = 4;
 	Space->Charset = TEXT("abc");
 
@@ -143,7 +142,8 @@ bool FProtobufTextSpaceSerializationTest::RunTest(const FString& Parameters)
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalSerializationTest, "Schola.Protobuf.Serialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FProtobufTextSpaceMinimalSerializationTest::RunTest(const FString& Parameters)
 {
-	// When min length and charset are unset, the optional proto fields should stay unset.
+	// min_length is always serialized. A default-constructed FTextSpace has MinLength 0
+	// (so an empty space stays coherent); charset stays unset when empty.
 	TInstancedStruct<FSpace> Inst;
 	Inst.InitializeAs<FTextSpace>();
 	FTextSpace* Space = Inst.GetMutablePtr<FTextSpace>();
@@ -156,7 +156,8 @@ bool FProtobufTextSpaceMinimalSerializationTest::RunTest(const FString& Paramete
 	if (OutProto.has_text_space())
 	{
 		TestEqual(TEXT("TextSpace.max_length == 10"), OutProto.text_space().max_length(), 10);
-		TestFalse(TEXT("TextSpace min_length unset"), OutProto.text_space().has_min_length());
+		TestTrue(TEXT("TextSpace has min_length set"), OutProto.text_space().has_min_length());
+		TestEqual(TEXT("TextSpace.min_length == 0"), OutProto.text_space().min_length(), 0);
 		TestFalse(TEXT("TextSpace charset unset"), OutProto.text_space().has_charset());
 	}
 

--- a/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
+++ b/Source/ScholaProtobuf/Private/Test/ProtobufUtils/SpaceSerializationTest.cpp
@@ -9,6 +9,7 @@
 #include "Spaces/DiscreteSpace.h"
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
+#include "Spaces/TextSpace.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufDiscreteSpaceSerializationTest, "Schola.Protobuf.Serialization.Spaces.Discrete", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FProtobufDiscreteSpaceSerializationTest::RunTest(const FString& Parameters)
@@ -107,6 +108,56 @@ bool FProtobufBoxSpaceSerializationTest::RunTest(const FString& Parameters)
 		auto& Shape = OutProto.box_space().shape_dimensions();
 		TestEqual(TEXT("BoxSpace.shape_dimensions size == 1"), (int)Shape.size(), 1);
 		TestEqual(TEXT("BoxSpace.shape_dimensions[0] == 2"), Shape.Get(0), 2);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceSerializationTest, "Schola.Protobuf.Serialization.Spaces.Text", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextSpaceSerializationTest::RunTest(const FString& Parameters)
+{
+	TInstancedStruct<FSpace> Inst;
+	Inst.InitializeAs<FTextSpace>();
+	FTextSpace* Space = Inst.GetMutablePtr<FTextSpace>();
+	Space->MaxLength = 32;
+	Space->bHasMinLength = true;
+	Space->MinLength = 4;
+	Space->Charset = TEXT("abc");
+
+	Schola::Space OutProto;
+	ProtobufSerializer::ToProto(Inst, &OutProto);
+
+	TestTrue(TEXT("Text space serialized as text_space"), OutProto.has_text_space());
+	if (OutProto.has_text_space())
+	{
+		TestEqual(TEXT("TextSpace.max_length == 32"), OutProto.text_space().max_length(), 32);
+		TestTrue(TEXT("TextSpace has min_length set"), OutProto.text_space().has_min_length());
+		TestEqual(TEXT("TextSpace.min_length == 4"), OutProto.text_space().min_length(), 4);
+		TestTrue(TEXT("TextSpace has charset set"), OutProto.text_space().has_charset());
+		TestEqual(TEXT("TextSpace.charset == abc"), FString(UTF8_TO_TCHAR(OutProto.text_space().charset().c_str())), FString(TEXT("abc")));
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FProtobufTextSpaceMinimalSerializationTest, "Schola.Protobuf.Serialization.Spaces.TextMinimal", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FProtobufTextSpaceMinimalSerializationTest::RunTest(const FString& Parameters)
+{
+	// When min length and charset are unset, the optional proto fields should stay unset.
+	TInstancedStruct<FSpace> Inst;
+	Inst.InitializeAs<FTextSpace>();
+	FTextSpace* Space = Inst.GetMutablePtr<FTextSpace>();
+	Space->MaxLength = 10;
+
+	Schola::Space OutProto;
+	ProtobufSerializer::ToProto(Inst, &OutProto);
+
+	TestTrue(TEXT("Text space serialized as text_space"), OutProto.has_text_space());
+	if (OutProto.has_text_space())
+	{
+		TestEqual(TEXT("TextSpace.max_length == 10"), OutProto.text_space().max_length(), 10);
+		TestFalse(TEXT("TextSpace min_length unset"), OutProto.text_space().has_min_length());
+		TestFalse(TEXT("TextSpace charset unset"), OutProto.text_space().has_charset());
 	}
 
 	return true;

--- a/Source/ScholaProtobuf/Public/Points.pb.h
+++ b/Source/ScholaProtobuf/Public/Points.pb.h
@@ -90,6 +90,10 @@ class Point;
 struct PointDefaultTypeInternal;
 SCHOLAPROTOBUF_API extern PointDefaultTypeInternal _Point_default_instance_;
 SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull Point_class_data_;
+class TextPoint;
+struct TextPointDefaultTypeInternal;
+SCHOLAPROTOBUF_API extern TextPointDefaultTypeInternal _TextPoint_default_instance_;
+SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull TextPoint_class_data_;
 }  // namespace Schola
 namespace google {
 namespace protobuf {
@@ -101,6 +105,202 @@ namespace Schola {
 // ===================================================================
 
 
+// -------------------------------------------------------------------
+
+class SCHOLAPROTOBUF_API TextPoint final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:Schola.TextPoint) */ {
+ public:
+  inline TextPoint() : TextPoint(nullptr) {}
+  ~TextPoint() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(TextPoint* PROTOBUF_NONNULL msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(TextPoint));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR TextPoint(::google::protobuf::internal::ConstantInitialized);
+
+  inline TextPoint(const TextPoint& from) : TextPoint(nullptr, from) {}
+  inline TextPoint(TextPoint&& from) noexcept
+      : TextPoint(nullptr, ::std::move(from)) {}
+  inline TextPoint& operator=(const TextPoint& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TextPoint& operator=(TextPoint&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* PROTOBUF_NONNULL mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* PROTOBUF_NONNULL GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const TextPoint& default_instance() {
+    return *reinterpret_cast<const TextPoint*>(
+        &_TextPoint_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 6;
+  friend void swap(TextPoint& a, TextPoint& b) { a.Swap(&b); }
+  inline void Swap(TextPoint* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(TextPoint* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  TextPoint* PROTOBUF_NONNULL New(::google::protobuf::Arena* PROTOBUF_NULLABLE arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<TextPoint>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const TextPoint& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const TextPoint& from) { TextPoint::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(::google::protobuf::MessageLite& to_msg,
+                        const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      const ::google::protobuf::MessageLite& msg, ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(TextPoint* PROTOBUF_NONNULL other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "Schola.TextPoint"; }
+
+ protected:
+  explicit TextPoint(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  TextPoint(::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const TextPoint& from);
+  TextPoint(
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, TextPoint&& from) noexcept
+      : TextPoint(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL GetClassData() const PROTOBUF_FINAL;
+  static void* PROTOBUF_NONNULL PlacementNew_(
+      const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static constexpr auto InternalNewImpl_();
+
+ public:
+  static constexpr auto InternalGenerateClassData_();
+
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kValueFieldNumber = 1,
+  };
+  // string value = 1;
+  void clear_value() ;
+  const ::std::string& value() const;
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_value(Arg_&& arg, Args_... args);
+  ::std::string* PROTOBUF_NONNULL mutable_value();
+  [[nodiscard]] ::std::string* PROTOBUF_NULLABLE release_value();
+  void set_allocated_value(::std::string* PROTOBUF_NULLABLE value);
+
+  private:
+  const ::std::string& _internal_value() const;
+  PROTOBUF_ALWAYS_INLINE void _internal_set_value(const ::std::string& value);
+  ::std::string* PROTOBUF_NONNULL _internal_mutable_value();
+
+  public:
+  // @@protoc_insertion_point(class_scope:Schola.TextPoint)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<0, 1,
+                                   0, 30,
+                                   2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+        const TextPoint& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr value_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Points_2eproto;
+};
+
+SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull TextPoint_class_data_;
 // -------------------------------------------------------------------
 
 class SCHOLAPROTOBUF_API MultiDiscretePoint final : public ::google::protobuf::Message
@@ -1221,9 +1421,10 @@ class SCHOLAPROTOBUF_API Point final : public ::google::protobuf::Message
     kMultiDiscretePoint = 3,
     kMultiBinaryPoint = 4,
     kDictPoint = 5,
+    kTextPoint = 6,
     POINT_NOT_SET = 0,
   };
-  static constexpr int kIndexInFileMessages = 6;
+  static constexpr int kIndexInFileMessages = 7;
   friend void swap(Point& a, Point& b) { a.Swap(&b); }
   inline void Swap(Point* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1316,6 +1517,7 @@ class SCHOLAPROTOBUF_API Point final : public ::google::protobuf::Message
     kMultiDiscretePointFieldNumber = 3,
     kMultiBinaryPointFieldNumber = 4,
     kDictPointFieldNumber = 5,
+    kTextPointFieldNumber = 6,
   };
   // .Schola.BoxPoint box_point = 1;
   bool has_box_point() const;
@@ -1412,6 +1614,25 @@ class SCHOLAPROTOBUF_API Point final : public ::google::protobuf::Message
   ::Schola::DictPoint* PROTOBUF_NONNULL _internal_mutable_dict_point();
 
   public:
+  // .Schola.TextPoint text_point = 6;
+  bool has_text_point() const;
+  private:
+  bool _internal_has_text_point() const;
+
+  public:
+  void clear_text_point() ;
+  const ::Schola::TextPoint& text_point() const;
+  [[nodiscard]] ::Schola::TextPoint* PROTOBUF_NULLABLE release_text_point();
+  ::Schola::TextPoint* PROTOBUF_NONNULL mutable_text_point();
+  void set_allocated_text_point(::Schola::TextPoint* PROTOBUF_NULLABLE value);
+  void unsafe_arena_set_allocated_text_point(::Schola::TextPoint* PROTOBUF_NULLABLE value);
+  ::Schola::TextPoint* PROTOBUF_NULLABLE unsafe_arena_release_text_point();
+
+  private:
+  const ::Schola::TextPoint& _internal_text_point() const;
+  ::Schola::TextPoint* PROTOBUF_NONNULL _internal_mutable_text_point();
+
+  public:
   void clear_point();
   PointCase point_case() const;
   // @@protoc_insertion_point(class_scope:Schola.Point)
@@ -1422,11 +1643,12 @@ class SCHOLAPROTOBUF_API Point final : public ::google::protobuf::Message
   void set_has_multi_discrete_point();
   void set_has_multi_binary_point();
   void set_has_dict_point();
+  void set_has_text_point();
   inline bool has_point() const;
   inline void clear_has_point();
   friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<0, 5,
-                                   5, 0,
+  static const ::google::protobuf::internal::TcParseTable<0, 6,
+                                   6, 0,
                                    2>
       _table_;
 
@@ -1453,6 +1675,7 @@ class SCHOLAPROTOBUF_API Point final : public ::google::protobuf::Message
       ::google::protobuf::Message* PROTOBUF_NULLABLE multi_discrete_point_;
       ::google::protobuf::Message* PROTOBUF_NULLABLE multi_binary_point_;
       ::google::protobuf::Message* PROTOBUF_NULLABLE dict_point_;
+      ::google::protobuf::Message* PROTOBUF_NULLABLE text_point_;
     } point_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -1757,6 +1980,75 @@ inline ::google::protobuf::Map<std::string, ::Schola::Point>* PROTOBUF_NONNULL D
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
   // @@protoc_insertion_point(field_mutable_map:Schola.DictPoint.values)
   return _internal_mutable_values();
+}
+
+// -------------------------------------------------------------------
+
+// TextPoint
+
+// string value = 1;
+inline void TextPoint::clear_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.value_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::std::string& TextPoint::value() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:Schola.TextPoint.value)
+  return _internal_value();
+}
+template <typename Arg_, typename... Args_>
+PROTOBUF_ALWAYS_INLINE void TextPoint::set_value(Arg_&& arg, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.value_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:Schola.TextPoint.value)
+}
+inline ::std::string* PROTOBUF_NONNULL TextPoint::mutable_value()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::std::string* _s = _internal_mutable_value();
+  // @@protoc_insertion_point(field_mutable:Schola.TextPoint.value)
+  return _s;
+}
+inline const ::std::string& TextPoint::_internal_value() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.value_.Get();
+}
+inline void TextPoint::_internal_set_value(const ::std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.value_.Set(value, GetArena());
+}
+inline ::std::string* PROTOBUF_NONNULL TextPoint::_internal_mutable_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.value_.Mutable( GetArena());
+}
+inline ::std::string* PROTOBUF_NULLABLE TextPoint::release_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:Schola.TextPoint.value)
+  if ((_impl_._has_bits_[0] & 0x00000001u) == 0) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* released = _impl_.value_.Release();
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
+    _impl_.value_.Set("", GetArena());
+  }
+  return released;
+}
+inline void TextPoint::set_allocated_value(::std::string* PROTOBUF_NULLABLE value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.value_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.value_.IsDefault()) {
+    _impl_.value_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:Schola.TextPoint.value)
 }
 
 // -------------------------------------------------------------------
@@ -2165,6 +2457,87 @@ inline ::Schola::DictPoint* PROTOBUF_NONNULL Point::mutable_dict_point()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::Schola::DictPoint* _msg = _internal_mutable_dict_point();
   // @@protoc_insertion_point(field_mutable:Schola.Point.dict_point)
+  return _msg;
+}
+
+// .Schola.TextPoint text_point = 6;
+inline bool Point::has_text_point() const {
+  return point_case() == kTextPoint;
+}
+inline bool Point::_internal_has_text_point() const {
+  return point_case() == kTextPoint;
+}
+inline void Point::set_has_text_point() {
+  _impl_._oneof_case_[0] = kTextPoint;
+}
+inline void Point::clear_text_point() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (point_case() == kTextPoint) {
+    if (GetArena() == nullptr) {
+      delete _impl_.point_.text_point_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.point_.text_point_);
+    }
+    clear_has_point();
+  }
+}
+inline ::Schola::TextPoint* PROTOBUF_NULLABLE Point::release_text_point() {
+  // @@protoc_insertion_point(field_release:Schola.Point.text_point)
+  if (point_case() == kTextPoint) {
+    clear_has_point();
+    auto* temp = reinterpret_cast<::Schola::TextPoint*>(_impl_.point_.text_point_);
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.point_.text_point_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::Schola::TextPoint& Point::_internal_text_point() const {
+  return point_case() == kTextPoint ? *reinterpret_cast<::Schola::TextPoint*>(_impl_.point_.text_point_) : reinterpret_cast<::Schola::TextPoint&>(::Schola::_TextPoint_default_instance_);
+}
+inline const ::Schola::TextPoint& Point::text_point() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:Schola.Point.text_point)
+  return _internal_text_point();
+}
+inline ::Schola::TextPoint* PROTOBUF_NULLABLE Point::unsafe_arena_release_text_point() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:Schola.Point.text_point)
+  if (point_case() == kTextPoint) {
+    clear_has_point();
+    auto* temp = reinterpret_cast<::Schola::TextPoint*>(_impl_.point_.text_point_);
+    _impl_.point_.text_point_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void Point::unsafe_arena_set_allocated_text_point(
+    ::Schola::TextPoint* PROTOBUF_NULLABLE value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_point();
+  if (value) {
+    set_has_text_point();
+    _impl_.point_.text_point_ = reinterpret_cast<::google::protobuf::Message*>(value);
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Schola.Point.text_point)
+}
+inline ::Schola::TextPoint* PROTOBUF_NONNULL Point::_internal_mutable_text_point() {
+  if (point_case() != kTextPoint) {
+    clear_point();
+    set_has_text_point();
+    _impl_.point_.text_point_ = reinterpret_cast<::google::protobuf::Message*>(
+        ::google::protobuf::Message::DefaultConstruct<::Schola::TextPoint>(GetArena()));
+  }
+  return reinterpret_cast<::Schola::TextPoint*>(_impl_.point_.text_point_);
+}
+inline ::Schola::TextPoint* PROTOBUF_NONNULL Point::mutable_text_point()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::Schola::TextPoint* _msg = _internal_mutable_text_point();
+  // @@protoc_insertion_point(field_mutable:Schola.Point.text_point)
   return _msg;
 }
 

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
@@ -222,19 +222,14 @@ public:
 		Space.Shape.Append(InBoxSpace.shape_dimensions().data(), InBoxSpace.shape_dimensions_size());
 	};
 
-	/** Deserializes length bounds and optional charset into FTextSpace. */
+	/** Deserializes length bounds and charset into FTextSpace. */
 	void Deserialize(const Schola::TextSpace& InTextSpace)
 	{
 		DeserializedSpace.InitializeAs<FTextSpace>();
 		FTextSpace& Space = DeserializedSpace.GetMutable<FTextSpace>();
 		Space.MaxLength = InTextSpace.max_length();
-		// min_length uses proto3 explicit presence; when absent (e.g. Python omits
-		// it because it equals Gymnasium's default of 1), apply Gymnasium's default of 1.
-		Space.MinLength = InTextSpace.has_min_length() ? InTextSpace.min_length() : 1;
-		if (InTextSpace.has_charset())
-		{
-			Space.Charset = FString(UTF8_TO_TCHAR(InTextSpace.charset().c_str()));
-		}
+		Space.MinLength = InTextSpace.min_length();
+		Space.Charset = FString(UTF8_TO_TCHAR(InTextSpace.charset().c_str()));
 	};
 };
 

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
@@ -7,6 +7,7 @@
 #include "Points/BoxPoint.h"
 #include "Points/DiscretePoint.h"
 #include "Points/DictPoint.h"
+#include "Points/TextPoint.h"
 #include "TrainingDataTypes/TrainingUpdate.h"
 #include "TrainingDataTypes/EnvironmentUpdate.h"
 #include "TrainingDataTypes/StartRequest.h"
@@ -17,6 +18,7 @@
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
 #include "Spaces/BoxSpaceDimension.h"
+#include "Spaces/TextSpace.h"
 #include "StructUtils/InstancedStruct.h"
 #include "ImitationConnectors/AbstractImitationConnector.h"
 THIRD_PARTY_INCLUDES_START
@@ -69,6 +71,10 @@ public:
 			case (Schola::Point::kMultiDiscretePoint):
 				this->Deserialize(InPoint.multi_discrete_point());
 				break;
+
+			case (Schola::Point::kTextPoint):
+				this->Deserialize(InPoint.text_point());
+				break;
 		}
 	};
 
@@ -113,6 +119,13 @@ public:
 		DeserializedPoint.InitializeAs<FDiscretePoint>(InDiscretePoint.value());
 	};
 
+	/** Deserializes a UTF-8 string into FTextPoint. */
+	void Deserialize(const Schola::TextPoint& InTextPoint)
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE_STR("ScholaProtobuf: Deserialize TextPoint");
+		DeserializedPoint.InitializeAs<FTextPoint>(FString(UTF8_TO_TCHAR(InTextPoint.value().c_str())));
+	};
+
 };
 
 /**
@@ -152,6 +165,9 @@ public:
 				break;
 			case Schola::Space::kBoxSpace:
 				this->Deserialize(InSpace.box_space());
+				break;
+			case Schola::Space::kTextSpace:
+				this->Deserialize(InSpace.text_space());
 				break;
 			case Schola::Space::SPACE_NOT_SET:
 			default:
@@ -204,6 +220,23 @@ public:
 		// Shape
 		Space.Shape.Empty();
 		Space.Shape.Append(InBoxSpace.shape_dimensions().data(), InBoxSpace.shape_dimensions_size());
+	};
+
+	/** Deserializes length bounds and optional charset into FTextSpace. */
+	void Deserialize(const Schola::TextSpace& InTextSpace)
+	{
+		DeserializedSpace.InitializeAs<FTextSpace>();
+		FTextSpace& Space = DeserializedSpace.GetMutable<FTextSpace>();
+		Space.MaxLength = InTextSpace.max_length();
+		Space.bHasMinLength = InTextSpace.has_min_length();
+		if (InTextSpace.has_min_length())
+		{
+			Space.MinLength = InTextSpace.min_length();
+		}
+		if (InTextSpace.has_charset())
+		{
+			Space.Charset = FString(UTF8_TO_TCHAR(InTextSpace.charset().c_str()));
+		}
 	};
 };
 

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufDeserializer.h
@@ -228,11 +228,9 @@ public:
 		DeserializedSpace.InitializeAs<FTextSpace>();
 		FTextSpace& Space = DeserializedSpace.GetMutable<FTextSpace>();
 		Space.MaxLength = InTextSpace.max_length();
-		Space.bHasMinLength = InTextSpace.has_min_length();
-		if (InTextSpace.has_min_length())
-		{
-			Space.MinLength = InTextSpace.min_length();
-		}
+		// min_length uses proto3 explicit presence; when absent (e.g. Python omits
+		// it because it equals Gymnasium's default of 1), apply Gymnasium's default of 1.
+		Space.MinLength = InTextSpace.has_min_length() ? InTextSpace.min_length() : 1;
 		if (InTextSpace.has_charset())
 		{
 			Space.Charset = FString(UTF8_TO_TCHAR(InTextSpace.charset().c_str()));

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
@@ -202,10 +202,7 @@ public:
 		Schola::TextSpace* ConcreteSpace = SerializedSpaceBuffer->mutable_text_space();
 		ConcreteSpace->set_max_length(Space.MaxLength);
 		ConcreteSpace->set_min_length(Space.MinLength);
-		if (!Space.Charset.IsEmpty())
-		{
-			ConcreteSpace->set_charset(TCHAR_TO_UTF8(*Space.Charset));
-		}
+		ConcreteSpace->set_charset(TCHAR_TO_UTF8(*Space.Charset));
 	};
 };
 

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
@@ -6,6 +6,7 @@
 #include "Points/DictPoint.h"
 #include "Points/DiscretePoint.h"
 #include "Points/MultiDiscretePoint.h"
+#include "Points/TextPoint.h"
 #include "Points/PointVisitor.h"	
 #include "Spaces/SpaceVisitor.h"
 #include "Spaces/DictSpace.h"
@@ -13,6 +14,7 @@
 #include "Spaces/DiscreteSpace.h"
 #include "Spaces/MultiDiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
+#include "Spaces/TextSpace.h"
 #include "Containers/StringConv.h"
 #include "TrainingDataTypes/EnvironmentState.h"
 #include "TrainingDataTypes/TrainingState.h"
@@ -109,6 +111,13 @@ public:
 		}
 	};
 
+	void operator()(const FTextPoint& Point) override
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE_STR("ScholaProtobuf: Serialize TextPoint");
+		Schola::TextPoint* PointMsg = SerializedPointBuffer->mutable_text_point();
+		PointMsg->set_value(TCHAR_TO_UTF8(*Point.Value));
+	};
+
 	/** @return Underlying Schola::Point buffer (e.g. after visiting dict entries). */
 	Schola::Point* GetDictPoint()
 	{
@@ -184,6 +193,21 @@ public:
 		for (int DimensionSize : Space.Shape)
 		{
 			ConcreteSpace->add_shape_dimensions(DimensionSize);
+		}
+	};
+
+	void operator()(const FTextSpace& Space) override
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE_STR("ScholaProtobuf: Serialize TextSpace");
+		Schola::TextSpace* ConcreteSpace = SerializedSpaceBuffer->mutable_text_space();
+		ConcreteSpace->set_max_length(Space.MaxLength);
+		if (Space.bHasMinLength)
+		{
+			ConcreteSpace->set_min_length(Space.MinLength);
+		}
+		if (!Space.Charset.IsEmpty())
+		{
+			ConcreteSpace->set_charset(TCHAR_TO_UTF8(*Space.Charset));
 		}
 	};
 };

--- a/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
+++ b/Source/ScholaProtobuf/Public/ProtobufUtils/ProtobufSerializer.h
@@ -201,10 +201,7 @@ public:
 		TRACE_CPUPROFILER_EVENT_SCOPE_STR("ScholaProtobuf: Serialize TextSpace");
 		Schola::TextSpace* ConcreteSpace = SerializedSpaceBuffer->mutable_text_space();
 		ConcreteSpace->set_max_length(Space.MaxLength);
-		if (Space.bHasMinLength)
-		{
-			ConcreteSpace->set_min_length(Space.MinLength);
-		}
+		ConcreteSpace->set_min_length(Space.MinLength);
 		if (!Space.Charset.IsEmpty())
 		{
 			ConcreteSpace->set_charset(TCHAR_TO_UTF8(*Space.Charset));

--- a/Source/ScholaProtobuf/Public/Spaces.pb.h
+++ b/Source/ScholaProtobuf/Public/Spaces.pb.h
@@ -258,8 +258,7 @@ class SCHOLAPROTOBUF_API TextSpace final : public ::google::protobuf::Message
     kMaxLengthFieldNumber = 1,
     kMinLengthFieldNumber = 2,
   };
-  // optional string charset = 3;
-  bool has_charset() const;
+  // string charset = 3;
   void clear_charset() ;
   const ::std::string& charset() const;
   template <typename Arg_ = const ::std::string&, typename... Args_>
@@ -284,8 +283,7 @@ class SCHOLAPROTOBUF_API TextSpace final : public ::google::protobuf::Message
   void _internal_set_max_length(::int32_t value);
 
   public:
-  // optional int32 min_length = 2;
-  bool has_min_length() const;
+  // int32 min_length = 2;
   void clear_min_length() ;
   ::int32_t min_length() const;
   void set_min_length(::int32_t value);
@@ -2235,11 +2233,7 @@ inline void TextSpace::_internal_set_max_length(::int32_t value) {
   _impl_.max_length_ = value;
 }
 
-// optional int32 min_length = 2;
-inline bool TextSpace::has_min_length() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000004u) != 0;
-  return value;
-}
+// int32 min_length = 2;
 inline void TextSpace::clear_min_length() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.min_length_ = 0;
@@ -2263,11 +2257,7 @@ inline void TextSpace::_internal_set_min_length(::int32_t value) {
   _impl_.min_length_ = value;
 }
 
-// optional string charset = 3;
-inline bool TextSpace::has_charset() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
-  return value;
-}
+// string charset = 3;
 inline void TextSpace::clear_charset() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.charset_.ClearToEmpty();

--- a/Source/ScholaProtobuf/Public/Spaces.pb.h
+++ b/Source/ScholaProtobuf/Public/Spaces.pb.h
@@ -94,6 +94,10 @@ class Space;
 struct SpaceDefaultTypeInternal;
 SCHOLAPROTOBUF_API extern SpaceDefaultTypeInternal _Space_default_instance_;
 SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull Space_class_data_;
+class TextSpace;
+struct TextSpaceDefaultTypeInternal;
+SCHOLAPROTOBUF_API extern TextSpaceDefaultTypeInternal _TextSpace_default_instance_;
+SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull TextSpace_class_data_;
 }  // namespace Schola
 namespace google {
 namespace protobuf {
@@ -105,6 +109,228 @@ namespace Schola {
 // ===================================================================
 
 
+// -------------------------------------------------------------------
+
+class SCHOLAPROTOBUF_API TextSpace final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:Schola.TextSpace) */ {
+ public:
+  inline TextSpace() : TextSpace(nullptr) {}
+  ~TextSpace() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(TextSpace* PROTOBUF_NONNULL msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(TextSpace));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR TextSpace(::google::protobuf::internal::ConstantInitialized);
+
+  inline TextSpace(const TextSpace& from) : TextSpace(nullptr, from) {}
+  inline TextSpace(TextSpace&& from) noexcept
+      : TextSpace(nullptr, ::std::move(from)) {}
+  inline TextSpace& operator=(const TextSpace& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TextSpace& operator=(TextSpace&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* PROTOBUF_NONNULL mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* PROTOBUF_NONNULL GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const TextSpace& default_instance() {
+    return *reinterpret_cast<const TextSpace*>(
+        &_TextSpace_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 5;
+  friend void swap(TextSpace& a, TextSpace& b) { a.Swap(&b); }
+  inline void Swap(TextSpace* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(TextSpace* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  TextSpace* PROTOBUF_NONNULL New(::google::protobuf::Arena* PROTOBUF_NULLABLE arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<TextSpace>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const TextSpace& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const TextSpace& from) { TextSpace::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(::google::protobuf::MessageLite& to_msg,
+                        const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      const ::google::protobuf::MessageLite& msg, ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(TextSpace* PROTOBUF_NONNULL other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "Schola.TextSpace"; }
+
+ protected:
+  explicit TextSpace(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  TextSpace(::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const TextSpace& from);
+  TextSpace(
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, TextSpace&& from) noexcept
+      : TextSpace(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL GetClassData() const PROTOBUF_FINAL;
+  static void* PROTOBUF_NONNULL PlacementNew_(
+      const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static constexpr auto InternalNewImpl_();
+
+ public:
+  static constexpr auto InternalGenerateClassData_();
+
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCharsetFieldNumber = 3,
+    kMaxLengthFieldNumber = 1,
+    kMinLengthFieldNumber = 2,
+  };
+  // optional string charset = 3;
+  bool has_charset() const;
+  void clear_charset() ;
+  const ::std::string& charset() const;
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_charset(Arg_&& arg, Args_... args);
+  ::std::string* PROTOBUF_NONNULL mutable_charset();
+  [[nodiscard]] ::std::string* PROTOBUF_NULLABLE release_charset();
+  void set_allocated_charset(::std::string* PROTOBUF_NULLABLE value);
+
+  private:
+  const ::std::string& _internal_charset() const;
+  PROTOBUF_ALWAYS_INLINE void _internal_set_charset(const ::std::string& value);
+  ::std::string* PROTOBUF_NONNULL _internal_mutable_charset();
+
+  public:
+  // int32 max_length = 1;
+  void clear_max_length() ;
+  ::int32_t max_length() const;
+  void set_max_length(::int32_t value);
+
+  private:
+  ::int32_t _internal_max_length() const;
+  void _internal_set_max_length(::int32_t value);
+
+  public:
+  // optional int32 min_length = 2;
+  bool has_min_length() const;
+  void clear_min_length() ;
+  ::int32_t min_length() const;
+  void set_min_length(::int32_t value);
+
+  private:
+  ::int32_t _internal_min_length() const;
+  void _internal_set_min_length(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:Schola.TextSpace)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<2, 3,
+                                   0, 32,
+                                   2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+        const TextSpace& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr charset_;
+    ::int32_t max_length_;
+    ::int32_t min_length_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Spaces_2eproto;
+};
+
+SCHOLAPROTOBUF_API extern const ::google::protobuf::internal::ClassDataFull TextSpace_class_data_;
 // -------------------------------------------------------------------
 
 class SCHOLAPROTOBUF_API MultiDiscreteSpace final : public ::google::protobuf::Message
@@ -1178,7 +1404,7 @@ class SCHOLAPROTOBUF_API DictSpace final : public ::google::protobuf::Message
     return *reinterpret_cast<const DictSpace*>(
         &_DictSpace_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 7;
+  static constexpr int kIndexInFileMessages = 8;
   friend void swap(DictSpace& a, DictSpace& b) { a.Swap(&b); }
   inline void Swap(DictSpace* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1421,9 +1647,10 @@ class SCHOLAPROTOBUF_API Space final : public ::google::protobuf::Message
     kMultiDiscreteSpace = 3,
     kMultiBinarySpace = 4,
     kDictSpace = 5,
+    kTextSpace = 6,
     SPACE_NOT_SET = 0,
   };
-  static constexpr int kIndexInFileMessages = 5;
+  static constexpr int kIndexInFileMessages = 6;
   friend void swap(Space& a, Space& b) { a.Swap(&b); }
   inline void Swap(Space* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1516,6 +1743,7 @@ class SCHOLAPROTOBUF_API Space final : public ::google::protobuf::Message
     kMultiDiscreteSpaceFieldNumber = 3,
     kMultiBinarySpaceFieldNumber = 4,
     kDictSpaceFieldNumber = 5,
+    kTextSpaceFieldNumber = 6,
   };
   // .Schola.BoxSpace box_space = 1;
   bool has_box_space() const;
@@ -1612,6 +1840,25 @@ class SCHOLAPROTOBUF_API Space final : public ::google::protobuf::Message
   ::Schola::DictSpace* PROTOBUF_NONNULL _internal_mutable_dict_space();
 
   public:
+  // .Schola.TextSpace text_space = 6;
+  bool has_text_space() const;
+  private:
+  bool _internal_has_text_space() const;
+
+  public:
+  void clear_text_space() ;
+  const ::Schola::TextSpace& text_space() const;
+  [[nodiscard]] ::Schola::TextSpace* PROTOBUF_NULLABLE release_text_space();
+  ::Schola::TextSpace* PROTOBUF_NONNULL mutable_text_space();
+  void set_allocated_text_space(::Schola::TextSpace* PROTOBUF_NULLABLE value);
+  void unsafe_arena_set_allocated_text_space(::Schola::TextSpace* PROTOBUF_NULLABLE value);
+  ::Schola::TextSpace* PROTOBUF_NULLABLE unsafe_arena_release_text_space();
+
+  private:
+  const ::Schola::TextSpace& _internal_text_space() const;
+  ::Schola::TextSpace* PROTOBUF_NONNULL _internal_mutable_text_space();
+
+  public:
   void clear_space();
   SpaceCase space_case() const;
   // @@protoc_insertion_point(class_scope:Schola.Space)
@@ -1622,11 +1869,12 @@ class SCHOLAPROTOBUF_API Space final : public ::google::protobuf::Message
   void set_has_multi_discrete_space();
   void set_has_multi_binary_space();
   void set_has_dict_space();
+  void set_has_text_space();
   inline bool has_space() const;
   inline void clear_has_space();
   friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<0, 5,
-                                   5, 0,
+  static const ::google::protobuf::internal::TcParseTable<0, 6,
+                                   6, 0,
                                    2>
       _table_;
 
@@ -1653,6 +1901,7 @@ class SCHOLAPROTOBUF_API Space final : public ::google::protobuf::Message
       ::google::protobuf::Message* PROTOBUF_NULLABLE multi_discrete_space_;
       ::google::protobuf::Message* PROTOBUF_NULLABLE multi_binary_space_;
       ::google::protobuf::Message* PROTOBUF_NULLABLE dict_space_;
+      ::google::protobuf::Message* PROTOBUF_NULLABLE text_space_;
     } space_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -1956,6 +2205,131 @@ inline ::int32_t MultiBinarySpace::_internal_shape() const {
 inline void MultiBinarySpace::_internal_set_shape(::int32_t value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.shape_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// TextSpace
+
+// int32 max_length = 1;
+inline void TextSpace::clear_max_length() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.max_length_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline ::int32_t TextSpace::max_length() const {
+  // @@protoc_insertion_point(field_get:Schola.TextSpace.max_length)
+  return _internal_max_length();
+}
+inline void TextSpace::set_max_length(::int32_t value) {
+  _internal_set_max_length(value);
+  _impl_._has_bits_[0] |= 0x00000002u;
+  // @@protoc_insertion_point(field_set:Schola.TextSpace.max_length)
+}
+inline ::int32_t TextSpace::_internal_max_length() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.max_length_;
+}
+inline void TextSpace::_internal_set_max_length(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.max_length_ = value;
+}
+
+// optional int32 min_length = 2;
+inline bool TextSpace::has_min_length() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000004u) != 0;
+  return value;
+}
+inline void TextSpace::clear_min_length() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.min_length_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000004u;
+}
+inline ::int32_t TextSpace::min_length() const {
+  // @@protoc_insertion_point(field_get:Schola.TextSpace.min_length)
+  return _internal_min_length();
+}
+inline void TextSpace::set_min_length(::int32_t value) {
+  _internal_set_min_length(value);
+  _impl_._has_bits_[0] |= 0x00000004u;
+  // @@protoc_insertion_point(field_set:Schola.TextSpace.min_length)
+}
+inline ::int32_t TextSpace::_internal_min_length() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.min_length_;
+}
+inline void TextSpace::_internal_set_min_length(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.min_length_ = value;
+}
+
+// optional string charset = 3;
+inline bool TextSpace::has_charset() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline void TextSpace::clear_charset() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.charset_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::std::string& TextSpace::charset() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:Schola.TextSpace.charset)
+  return _internal_charset();
+}
+template <typename Arg_, typename... Args_>
+PROTOBUF_ALWAYS_INLINE void TextSpace::set_charset(Arg_&& arg, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.charset_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:Schola.TextSpace.charset)
+}
+inline ::std::string* PROTOBUF_NONNULL TextSpace::mutable_charset()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::std::string* _s = _internal_mutable_charset();
+  // @@protoc_insertion_point(field_mutable:Schola.TextSpace.charset)
+  return _s;
+}
+inline const ::std::string& TextSpace::_internal_charset() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.charset_.Get();
+}
+inline void TextSpace::_internal_set_charset(const ::std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.charset_.Set(value, GetArena());
+}
+inline ::std::string* PROTOBUF_NONNULL TextSpace::_internal_mutable_charset() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.charset_.Mutable( GetArena());
+}
+inline ::std::string* PROTOBUF_NULLABLE TextSpace::release_charset() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:Schola.TextSpace.charset)
+  if ((_impl_._has_bits_[0] & 0x00000001u) == 0) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* released = _impl_.charset_.Release();
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
+    _impl_.charset_.Set("", GetArena());
+  }
+  return released;
+}
+inline void TextSpace::set_allocated_charset(::std::string* PROTOBUF_NULLABLE value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.charset_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.charset_.IsDefault()) {
+    _impl_.charset_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:Schola.TextSpace.charset)
 }
 
 // -------------------------------------------------------------------
@@ -2364,6 +2738,87 @@ inline ::Schola::DictSpace* PROTOBUF_NONNULL Space::mutable_dict_space()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::Schola::DictSpace* _msg = _internal_mutable_dict_space();
   // @@protoc_insertion_point(field_mutable:Schola.Space.dict_space)
+  return _msg;
+}
+
+// .Schola.TextSpace text_space = 6;
+inline bool Space::has_text_space() const {
+  return space_case() == kTextSpace;
+}
+inline bool Space::_internal_has_text_space() const {
+  return space_case() == kTextSpace;
+}
+inline void Space::set_has_text_space() {
+  _impl_._oneof_case_[0] = kTextSpace;
+}
+inline void Space::clear_text_space() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (space_case() == kTextSpace) {
+    if (GetArena() == nullptr) {
+      delete _impl_.space_.text_space_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.space_.text_space_);
+    }
+    clear_has_space();
+  }
+}
+inline ::Schola::TextSpace* PROTOBUF_NULLABLE Space::release_text_space() {
+  // @@protoc_insertion_point(field_release:Schola.Space.text_space)
+  if (space_case() == kTextSpace) {
+    clear_has_space();
+    auto* temp = reinterpret_cast<::Schola::TextSpace*>(_impl_.space_.text_space_);
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.space_.text_space_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::Schola::TextSpace& Space::_internal_text_space() const {
+  return space_case() == kTextSpace ? *reinterpret_cast<::Schola::TextSpace*>(_impl_.space_.text_space_) : reinterpret_cast<::Schola::TextSpace&>(::Schola::_TextSpace_default_instance_);
+}
+inline const ::Schola::TextSpace& Space::text_space() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:Schola.Space.text_space)
+  return _internal_text_space();
+}
+inline ::Schola::TextSpace* PROTOBUF_NULLABLE Space::unsafe_arena_release_text_space() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:Schola.Space.text_space)
+  if (space_case() == kTextSpace) {
+    clear_has_space();
+    auto* temp = reinterpret_cast<::Schola::TextSpace*>(_impl_.space_.text_space_);
+    _impl_.space_.text_space_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void Space::unsafe_arena_set_allocated_text_space(
+    ::Schola::TextSpace* PROTOBUF_NULLABLE value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_space();
+  if (value) {
+    set_has_text_space();
+    _impl_.space_.text_space_ = reinterpret_cast<::google::protobuf::Message*>(value);
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Schola.Space.text_space)
+}
+inline ::Schola::TextSpace* PROTOBUF_NONNULL Space::_internal_mutable_text_space() {
+  if (space_case() != kTextSpace) {
+    clear_space();
+    set_has_text_space();
+    _impl_.space_.text_space_ = reinterpret_cast<::google::protobuf::Message*>(
+        ::google::protobuf::Message::DefaultConstruct<::Schola::TextSpace>(GetArena()));
+  }
+  return reinterpret_cast<::Schola::TextSpace*>(_impl_.space_.text_space_);
+}
+inline ::Schola::TextSpace* PROTOBUF_NONNULL Space::mutable_text_space()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::Schola::TextSpace* _msg = _internal_mutable_text_space();
+  // @@protoc_insertion_point(field_mutable:Schola.Space.text_space)
   return _msg;
 }
 

--- a/Test/core/protobuf/test_deserialization.py
+++ b/Test/core/protobuf/test_deserialization.py
@@ -97,12 +97,19 @@ class TestTextPoint:
 
 class TestTextSpace:
     def test_defaults(self):
-        """Absent min_length/charset should fall back to Gymnasium defaults."""
+        """All fields are copied verbatim; an empty charset maps to an empty set."""
         space = from_proto(TextSpace(max_length=10))
         assert isinstance(space, spaces.Text), "Should deserialize to a Text space"
         assert space.max_length == 10, "max_length should be 10"
-        assert space.min_length == 1, "min_length should default to 1"
-        assert len(space.character_set) > 0, "charset should use Gym default"
+        assert space.min_length == 0, "min_length should be copied verbatim"
+        assert space.character_set == frozenset(), "empty charset should map to the empty set"
+
+    def test_empty_charset_is_literal(self):
+        """An explicit empty charset is the empty set (only the empty string is valid)."""
+        space = from_proto(TextSpace(max_length=5, min_length=0, charset=""))
+        assert space.character_set == frozenset(), "charset should be the empty set"
+        assert space.contains(""), "empty string should be a valid point"
+        assert not space.contains("a"), "no non-empty string should be valid"
 
     def test_explicit_fields(self):
         space = from_proto(TextSpace(max_length=8, min_length=2, charset="abc"))

--- a/Test/core/protobuf/test_deserialization.py
+++ b/Test/core/protobuf/test_deserialization.py
@@ -6,8 +6,10 @@ import pytest
 
 from schola.core.protocols.protobuf.deserialize import from_proto
 from schola.generated.Points_pb2 import *
+from schola.generated.Spaces_pb2 import *
 from schola.generated.DType_pb2 import *
 import numpy as np
+import gymnasium.spaces as spaces
 
 
 class TestDiscretePoint:
@@ -81,6 +83,36 @@ class TestBoxPoint:
         ), "BoxPoint with values [1.0, 2.0, 1.0, 2.0] and shape [2, 2] should deserialize to np.array([[1.0, 2.0], [1.0, 2.0]], dtype=np.float32)"
 
 
+class TestTextPoint:
+    def test_value(self):
+        point = TextPoint(value="one two")
+        assert (
+            from_proto(point) == "one two"
+        ), "TextPoint with value 'one two' should deserialize to 'one two'"
+
+    def test_empty(self):
+        point = TextPoint()
+        assert from_proto(point) == "", "Empty TextPoint should deserialize to ''"
+
+
+class TestTextSpace:
+    def test_defaults(self):
+        """Absent min_length/charset should fall back to Gymnasium defaults."""
+        space = from_proto(TextSpace(max_length=10))
+        assert isinstance(space, spaces.Text), "Should deserialize to a Text space"
+        assert space.max_length == 10, "max_length should be 10"
+        assert space.min_length == 1, "min_length should default to 1"
+        assert len(space.character_set) > 0, "charset should use Gym default"
+
+    def test_explicit_fields(self):
+        space = from_proto(TextSpace(max_length=8, min_length=2, charset="abc"))
+        assert space.max_length == 8, "max_length should be 8"
+        assert space.min_length == 2, "min_length should be 2"
+        assert space.character_set == frozenset(
+            "abc"
+        ), "charset should be {a, b, c}"
+
+
 class TestDictPoint:
 
     def test_empty(self):
@@ -142,6 +174,12 @@ class TestPoint:
         assert np.all(
             from_proto(point) == np.array([True, False, True], dtype=np.bool_)
         ), "Point with multi_binary_point [True, False, True] should deserialize to np.array([True, False, True], dtype=np.bool_)"
+
+    def test_text_point(self):
+        point = Point(text_point=TextPoint(value="hello"))
+        assert (
+            from_proto(point) == "hello"
+        ), "Point with text_point 'hello' should deserialize to 'hello'"
 
     def test_dict_point(self):
         point = Point(

--- a/Test/core/protobuf/test_serialization.py
+++ b/Test/core/protobuf/test_serialization.py
@@ -133,12 +133,13 @@ class TestTextPoint:
 class TestTextSpace:
 
     def test_defaults(self):
-        """Only max_length set; min_length/charset left to Gymnasium defaults."""
+        """Only max_length set; min_length/charset left unset so Gymnasium defaults apply."""
         space = Text(max_length=12)
         proto = space_to_proto(space)
         assert isinstance(proto, TextSpace), "Serialized space should be TextSpace"
         assert proto.max_length == 12, "TextSpace max_length should be 12"
-        assert proto.min_length == 1, "TextSpace min_length should default to 1"
+        assert not proto.HasField("min_length"), "min_length should be left unset for default (1)"
+        assert not proto.HasField("charset"), "charset should be left unset for default (alphanumeric)"
 
     def test_explicit_charset_is_sorted(self):
         """Charset is serialized as a deterministic, deduplicated sorted string."""

--- a/Test/core/protobuf/test_serialization.py
+++ b/Test/core/protobuf/test_serialization.py
@@ -9,6 +9,7 @@ from schola.generated.Spaces_pb2 import *
 from schola.generated.DType_pb2 import *
 import numpy as np
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, MultiBinary, Dict, Text
+from gymnasium.spaces.text import alphanumeric
 
 
 class TestDiscretePoint:
@@ -133,13 +134,15 @@ class TestTextPoint:
 class TestTextSpace:
 
     def test_defaults(self):
-        """Only max_length set; min_length/charset left unset so Gymnasium defaults apply."""
+        """All fields are serialized verbatim, including Gymnasium's own defaults."""
         space = Text(max_length=12)
         proto = space_to_proto(space)
         assert isinstance(proto, TextSpace), "Serialized space should be TextSpace"
         assert proto.max_length == 12, "TextSpace max_length should be 12"
-        assert not proto.HasField("min_length"), "min_length should be left unset for default (1)"
-        assert not proto.HasField("charset"), "charset should be left unset for default (alphanumeric)"
+        assert proto.min_length == 1, "min_length should be Gymnasium's default of 1"
+        assert proto.charset == "".join(
+            sorted(alphanumeric)
+        ), "charset should be the sorted default alphanumeric set"
 
     def test_explicit_charset_is_sorted(self):
         """Charset is serialized as a deterministic, deduplicated sorted string."""
@@ -147,6 +150,12 @@ class TestTextSpace:
         proto = space_to_proto(space)
         assert proto.min_length == 2, "TextSpace min_length should be 2"
         assert proto.charset == "abc", "Charset should be sorted/deduplicated to 'abc'"
+
+    def test_empty_charset_is_literal(self):
+        """An empty character set serializes to an empty charset (the empty set)."""
+        space = Text(max_length=8, charset="")
+        proto = space_to_proto(space)
+        assert proto.charset == "", "Empty character set should serialize to an empty charset"
 
 
 class TestDictPoint:

--- a/Test/core/protobuf/test_serialization.py
+++ b/Test/core/protobuf/test_serialization.py
@@ -3,11 +3,12 @@
 
 import pytest
 
-from schola.core.protocols.protobuf.serialize import to_proto
+from schola.core.protocols.protobuf.serialize import to_proto, space_to_proto
 from schola.generated.Points_pb2 import *
+from schola.generated.Spaces_pb2 import *
 from schola.generated.DType_pb2 import *
 import numpy as np
-from gymnasium.spaces import Box, Discrete, MultiDiscrete, MultiBinary, Dict
+from gymnasium.spaces import Box, Discrete, MultiDiscrete, MultiBinary, Dict, Text
 
 
 class TestDiscretePoint:
@@ -112,6 +113,41 @@ class TestBoxPoint:
         assert list(point.shape) == [2, 2], "BoxPoint shape should be [2, 2]"
 
 
+class TestTextPoint:
+
+    def test_value(self):
+        """Test serialization of a string to TextPoint"""
+        space = Text(max_length=16)
+        point = to_proto(space, "six seven")
+        assert isinstance(point, TextPoint), "Serialized point should be TextPoint"
+        assert point.value == "six seven", "TextPoint value should be 'hello'"
+
+    def test_empty_string(self):
+        """Test serialization of an empty string to TextPoint"""
+        space = Text(max_length=16)
+        point = to_proto(space, "")
+        assert isinstance(point, TextPoint), "Serialized point should be TextPoint"
+        assert point.value == "", "TextPoint value should be empty"
+
+
+class TestTextSpace:
+
+    def test_defaults(self):
+        """Only max_length set; min_length/charset left to Gymnasium defaults."""
+        space = Text(max_length=12)
+        proto = space_to_proto(space)
+        assert isinstance(proto, TextSpace), "Serialized space should be TextSpace"
+        assert proto.max_length == 12, "TextSpace max_length should be 12"
+        assert proto.min_length == 1, "TextSpace min_length should default to 1"
+
+    def test_explicit_charset_is_sorted(self):
+        """Charset is serialized as a deterministic, deduplicated sorted string."""
+        space = Text(max_length=8, min_length=2, charset="cba")
+        proto = space_to_proto(space)
+        assert proto.min_length == 2, "TextSpace min_length should be 2"
+        assert proto.charset == "abc", "Charset should be sorted/deduplicated to 'abc'"
+
+
 class TestDictPoint:
 
     def test_empty(self):
@@ -178,6 +214,13 @@ class TestPoint:
             2,
             3,
         ], "MultiDiscretePoint values should be [1, 2, 3]"
+
+    def test_text_point(self):
+        """Test serialization of a string produces TextPoint"""
+        space = Text(max_length=16)
+        point = to_proto(space, "abc")
+        assert isinstance(point, TextPoint), "Serialized point should be TextPoint"
+        assert point.value == "abc", "TextPoint value should be 'abc'"
 
     def test_multi_binary_point(self):
         """Test serialization of [True, False, True] produces MultiBinaryPoint in Point"""

--- a/Test/testing_spaces.py
+++ b/Test/testing_spaces.py
@@ -63,10 +63,9 @@ TESTING_FUNDAMENTAL_SPACES = [
     # MultiDiscrete([[2, 3], [3, 2]], start=[[10, 20], [30, 40]]),
     MultiBinary(8),
     # MultiBinary([2, 3]),
-    # Text Not supported by Schola yet
-    # Text(6),
-    # Text(min_length=3, max_length=6),
-    # Text(6, charset="abcdef"),
+    Text(6),
+    Text(min_length=3, max_length=6),
+    Text(6, charset="abcdef"),
 ]
 TESTING_FUNDAMENTAL_SPACES_IDS = [f"{space}" for space in TESTING_FUNDAMENTAL_SPACES]
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->
Adds support for Gymnasium's 'Text' Space and 'Text' Point across the entire Schola stack. 
Extended protocol schema and regenerated the Python bindings
Updated Python  and C++ serialization and deserialization
Added Python and C++ tests

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] New feature or enhancement

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
Add new files for Gymnasium Text Spaces/points across proto, Python (serialization and deserialization), C++ (structs, blueprint, visitors, tests)

I made the design choice to implement min_length and charset in the proto as optional.
Pros: serializer is able to omit when they match Gym's defaults, so deserializer doesn't have to guess between not provided and 0/"". 

Ex: for non-optional design, if a user doesn't pass in a 'min_length', we cannot differentiate between "" being allowed (0 min_length) and not setting min_length so default is 1.

Cons: Consumers must have branch for HasField

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Built / recompiled the project after Unreal Engine changes
- [x] Ran relevant automation tests (editor or pytest on Windows; see CONTRIBUTING.md)

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
