### PR TITLE
feat(python): expose target_kl early-stop threshold for SB3 PPO training

### DIFF
--- a/Resources/python/schola/scripts/sb3/train/settings.py
+++ b/Resources/python/schola/scripts/sb3/train/settings.py
@@ -95,6 +95,11 @@ class PPOTrainSettings(BaseSb3AlgorithmSettings, BasePPOSettings):
     sde_sample_freq: int = -1
     "Frequency at which to sample the SDE noise. This determines how often the noise is sampled when using State Dependent Exploration (SDE). A value of -1 means that it will sample the noise at every step, while a positive integer will specify the number of steps between samples. This can help to control the exploration behavior of the agent."
 
+    target_kl: Annotated[
+        Optional[float], Parameter(validator=validators.Number(gt=0.0))
+    ] = None
+    "Approximate KL-divergence threshold used to early-stop the PPO update epoch loop when the policy moves too far from the rollout distribution. When set, SB3 stops the inner epoch loop as soon as the running approximate KL exceeds this value, which stabilizes training when ``train/approx_kl`` would otherwise blow past ``clip_range``. Typical values are 0.01-0.05. Leave as None to disable (SB3's default)."
+
     def __post_init__(self):
         super().__post_init__()
         if self.normalize_advantage and self.batch_size <= 1:

--- a/Test/sb3/scripts/test_train_cli.py
+++ b/Test/sb3/scripts/test_train_cli.py
@@ -104,6 +104,7 @@ def test_ppo_cli_default_args(mock_app, mock_main):
     assert args.algorithm_settings.normalize_advantage == True
     assert args.algorithm_settings.ent_coef == 0.0
     assert args.algorithm_settings.vf_coef == 0.5
+    assert args.algorithm_settings.target_kl is None
 
 
 def test_ppo_cli_custom_args(mock_app, mock_main):
@@ -131,6 +132,8 @@ def test_ppo_cli_custom_args(mock_app, mock_main):
             "0.01",
             "--vf-coef",
             "0.25",
+            "--target-kl",
+            "0.03",
             "--timesteps",
             "10000",
         ],
@@ -156,6 +159,7 @@ def test_ppo_cli_custom_args(mock_app, mock_main):
     assert args.algorithm_settings.clip_range == 0.3
     assert args.algorithm_settings.ent_coef == 0.01
     assert args.algorithm_settings.vf_coef == 0.25
+    assert args.algorithm_settings.target_kl == 0.03
 
     # Verify top-level args
     assert args.training_settings.timesteps == 10000


### PR DESCRIPTION
## Summary

Adds a `--target-kl` CLI option for SB3 PPO training so users can set Stable Baselines 3’s approximate KL early-stop threshold. Default remains `None` (SB3’s default: disabled).

## Related issues

None.

## Type of change

- [x] New feature or enhancement

## Changes

- Added optional `target_kl` field to `PPOTrainSettings` in `Resources/python/schola/scripts/sb3/train/settings.py`, with validation `> 0.0` and default `None`.
- Exposed the setting on the SB3 train CLI as `--target-kl`.
- Extended `Test/sb3/scripts/test_train_cli.py` to assert the default is `None` and that a custom value (0.03) is parsed correctly.


## Testing

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

All cases pass.

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
