### PR TITLE
fix(python): cleanup unreal processes on ctrl-c in SB3

### DIFF
--- a/Resources/python/schola/scripts/sb3/eval/eval.py
+++ b/Resources/python/schola/scripts/sb3/eval/eval.py
@@ -5,6 +5,7 @@ Evaluate a trained Stable-Baselines3 policy against a Schola-backed environment.
 """
 
 import logging
+import signal
 from typing import List, Tuple, cast, Any
 
 from cyclopts import App
@@ -122,7 +123,8 @@ def main(args: Sb3EvalScriptSettings) -> Tuple[float, float]:
             return mean_reward, std_reward
     except (KeyboardInterrupt, Exception) as e:
         if isinstance(e, KeyboardInterrupt):
-            logger.info("Ctrl-C received. Shutting down gracefully; please do not press Ctrl-C again.")
+            logger.info("Ctrl-C received. Shutting down gracefully;")
+            signal.signal(signal.SIGINT, signal.SIG_IGN)  # Protect cleanup phase
         if env is not None:
             env.close()
         raise

--- a/Resources/python/schola/scripts/sb3/eval/eval.py
+++ b/Resources/python/schola/scripts/sb3/eval/eval.py
@@ -120,7 +120,9 @@ def main(args: Sb3EvalScriptSettings) -> Tuple[float, float]:
 
             monitored.close()
             return mean_reward, std_reward
-    except Exception:
+    except (KeyboardInterrupt, Exception) as e:
+        if isinstance(e, KeyboardInterrupt):
+            logger.info("Ctrl-C received. Shutting down gracefully; please do not press Ctrl-C again.")
         if env is not None:
             env.close()
         raise

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -7,6 +7,7 @@ Script to train a Stable Baselines3 model using Schola.
 from dataclasses import asdict
 import os
 import logging
+import signal
 from typing import (
     Any,
     Dict,
@@ -373,8 +374,9 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
                 env.close()
     except (KeyboardInterrupt, Exception) as e:
         if isinstance(e, KeyboardInterrupt):
-            logger.info("Ctrl-C received. Shutting down gracefully; please do not press Ctrl-C again.")
-        if env:
+            logger.info("Ctrl-C received. Shutting down gracefully;")
+            signal.signal(signal.SIGINT, signal.SIG_IGN)  # Protect cleanup phase
+        if env is not None:
             env.close()
         raise
 

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -371,10 +371,12 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
             else:
                 logger.info("Evaluation disabled. Skipping.")
                 env.close()
-    except Exception as e:
+    except (KeyboardInterrupt, Exception) as e:
+        if isinstance(e, KeyboardInterrupt):
+            logger.info("Ctrl-C received. Shutting down gracefully; please do not press Ctrl-C again.")
         if env:
             env.close()
-        raise e
+        raise
 
 
 app = App(name="train", help="Train a model using StableBaselines3")


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Bug fix

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
Added handling for Ctrl-C in SB3 to kill Unreal Engine processes. I also added a signal.signal(...) to block furhter ctrl-c attempts (which may stop env.close() from running)

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
