### PR TITLE
feat(unreal): Standardized Debug String Handling for Points and Spaces

### DIFF
--- a/Source/Schola/Private/Points/Blueprint/DiscretePointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/DiscretePointBlueprintLibrary.cpp
@@ -27,5 +27,6 @@ int32 UDiscretePointBlueprintLibrary::DiscretePointToInt32(const TInstancedStruc
     }
 
     return TypedPoint->Value;
+
 }
 

--- a/Source/Schola/Private/Points/Blueprint/MultiDiscretePointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/MultiDiscretePointBlueprintLibrary.cpp
@@ -1,31 +1,47 @@
 // Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
+
+
 #include "Points/Blueprint/MultiDiscretePointBlueprintLibrary.h"
 #include "Points/MultiDiscretePoint.h"
 #include "Common/BlueprintErrorUtils.h"
 
+
+
 TInstancedStruct<FMultiDiscretePoint> UMultiDiscretePointBlueprintLibrary::ArrayToMultiDiscretePoint(const TArray<int32>& InValues)
 {
+
 	return TInstancedStruct<FMultiDiscretePoint>::Make(InValues);
+
 }
+
+
 
 TArray<int32> UMultiDiscretePointBlueprintLibrary::MultiDiscretePointToArray(const TInstancedStruct<FMultiDiscretePoint>& InMultiDiscretePoint)
 {
     // Type check: ensure the InstancedStruct is actually a FMultiDiscretePoint
+
     if (!InMultiDiscretePoint.IsValid())
     {
+
         RaiseInvalidInstancedStructError(TEXT("MultiDiscretePointToArray"));
+
         return TArray<int32>();
+
     }
 
     const FMultiDiscretePoint* TypedPoint = InMultiDiscretePoint.GetPtr<FMultiDiscretePoint>();
-    
+
     if (!TypedPoint)
     {
+
         RaiseInstancedStructTypeMismatchError(InMultiDiscretePoint, TEXT("FMultiDiscretePoint"), TEXT("MultiDiscretePointToArray"));
+
         return TArray<int32>();
+
     }
 
     return TypedPoint->Values;
+
 }
 

--- a/Source/Schola/Private/Points/Blueprint/PointBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Points/Blueprint/PointBlueprintLibrary.cpp
@@ -2,6 +2,7 @@
 
 #include "Points/Blueprint/PointBlueprintLibrary.h"
 
+#include "Common/BlueprintErrorUtils.h"
 #include "Points/MultiBinaryPoint.h"
 #include "Points/DiscretePoint.h"
 #include "Points/BoxPoint.h"
@@ -47,4 +48,23 @@ EPointType UPointBlueprintLibrary::Point_Type(const FInstancedStruct& InPoint)
 bool UPointBlueprintLibrary::Point_IsOfType(const FInstancedStruct& InPoint, EPointType InType)
 {
 	return Point_Type(InPoint) == InType;
+}
+
+FString UPointBlueprintLibrary::PointToString(const FInstancedStruct& InPoint)
+{
+	if (!InPoint.IsValid())
+	{
+		RaiseInvalidInstancedStructError(TEXT("PointToString"));
+		return FString();
+	}
+
+	const UScriptStruct* ScriptStruct = InPoint.GetScriptStruct();
+	if (!ScriptStruct || !ScriptStruct->IsChildOf(FPoint::StaticStruct()))
+	{
+		RaiseInstancedStructTypeMismatchError(InPoint, TEXT("FPoint"), TEXT("PointToString"));
+		return FString();
+	}
+
+	const FPoint* Point = InPoint.GetPtr<FPoint>();
+	return Point ? Point->ToString() : FString();
 }

--- a/Source/Schola/Private/Spaces/Blueprint/SpaceBlueprintLibrary.cpp
+++ b/Source/Schola/Private/Spaces/Blueprint/SpaceBlueprintLibrary.cpp
@@ -73,3 +73,22 @@ bool USpaceBlueprintLibrary::Space_Contains(const FInstancedStruct& InSpace, con
 
 	return InSpace.GetPtr<FSpace>()->Contains(ToTypedInstancedStruct<FPoint>(InPoint));
 }
+
+FString USpaceBlueprintLibrary::SpaceToString(const FInstancedStruct& InSpace)
+{
+	if (!InSpace.IsValid())
+	{
+		RaiseInvalidInstancedStructError(TEXT("SpaceToString"));
+		return FString();
+	}
+
+	const UScriptStruct* ScriptStruct = InSpace.GetScriptStruct();
+	if (!ScriptStruct || !ScriptStruct->IsChildOf(FSpace::StaticStruct()))
+	{
+		RaiseInstancedStructTypeMismatchError(InSpace, TEXT("FSpace"), TEXT("SpaceToString"));
+		return FString();
+	}
+
+	const FSpace* Space = InSpace.GetPtr<FSpace>();
+	return Space ? Space->ToString() : FString();
+}

--- a/Source/Schola/Private/Spaces/BoxSpace.cpp
+++ b/Source/Schola/Private/Spaces/BoxSpace.cpp
@@ -193,6 +193,34 @@ bool FBoxSpace::IsEmpty() const
 	return this->Dimensions.IsEmpty();
 }
 
+FString FBoxSpace::ToString() const
+{
+	FString DimPart;
+	for (int32 i = 0; i < Dimensions.Num(); ++i)
+	{
+		if (i > 0)
+		{
+			DimPart += TEXT(", ");
+		}
+		DimPart += FString::Printf(TEXT("[%.6g, %.6g]"), Dimensions[i].Low, Dimensions[i].High);
+	}
+	FString ShapePart;
+	if (Shape.Num() > 0)
+	{
+		ShapePart += TEXT(", Shape=[");
+		for (int32 i = 0; i < Shape.Num(); ++i)
+		{
+			if (i > 0)
+			{
+				ShapePart += TEXT(", ");
+			}
+			ShapePart += FString::FromInt(Shape[i]);
+		}
+		ShapePart += TEXT("]");
+	}
+	return FString::Printf(TEXT("BoxSpace(Dimensions={%s}%s)"), *DimPart, *ShapePart);
+}
+
 void FBoxSpace::Add(float Low, float High)
 {
 	this->Dimensions.Emplace(Low, High);

--- a/Source/Schola/Private/Spaces/DictSpace.cpp
+++ b/Source/Schola/Private/Spaces/DictSpace.cpp
@@ -72,3 +72,15 @@ ESpaceValidationResult FDictSpace::Validate(const TInstancedStruct<FPoint>& InPo
 	}
 	return ESpaceValidationResult::Success;
 }
+
+FString FDictSpace::ToString() const
+{
+	FString Body;
+	for (const TPair<FString, TInstancedStruct<FSpace>>& Pair : Spaces)
+	{
+		const FSpace* SubSpace = Pair.Value.GetPtr<FSpace>();
+		const FString SubStr = SubSpace ? SubSpace->ToString() : TEXT("(null)");
+		Body += FString::Printf(TEXT("\t%s: %s,\n"), *Pair.Key, *SubStr);
+	}
+	return FString::Printf(TEXT("DictSpace(\n{%s})"), *Body);
+}

--- a/Source/Schola/Private/Spaces/DiscreteSpace.cpp
+++ b/Source/Schola/Private/Spaces/DiscreteSpace.cpp
@@ -63,3 +63,8 @@ bool FDiscreteSpace::IsEmpty() const
 {
 	return this->High == 0;
 }
+
+FString FDiscreteSpace::ToString() const
+{
+	return FString::Printf(TEXT("DiscreteSpace(High=%d)"), High);
+}

--- a/Source/Schola/Private/Spaces/MultiBinarySpace.cpp
+++ b/Source/Schola/Private/Spaces/MultiBinarySpace.cpp
@@ -50,3 +50,8 @@ bool FMultiBinarySpace::IsEmpty() const
 {
     return this->Shape == 0;
 }
+
+FString FMultiBinarySpace::ToString() const
+{
+	return FString::Printf(TEXT("MultiBinarySpace(Shape=%d)"), Shape);
+}

--- a/Source/Schola/Private/Spaces/MultiDiscreteSpace.cpp
+++ b/Source/Schola/Private/Spaces/MultiDiscreteSpace.cpp
@@ -95,3 +95,17 @@ bool FMultiDiscreteSpace::IsEmpty() const
 {
 	return this->High.Num() == 0;
 }
+
+FString FMultiDiscreteSpace::ToString() const
+{
+	FString HighPart;
+	for (int32 i = 0; i < High.Num(); ++i)
+	{
+		if (i > 0)
+		{
+			HighPart += TEXT(", ");
+		}
+		HighPart += FString::FromInt(High[i]);
+	}
+	return FString::Printf(TEXT("MultiDiscreteSpace(High=[%s])"), *HighPart);
+}

--- a/Source/Schola/Private/Spaces/TextSpace.cpp
+++ b/Source/Schola/Private/Spaces/TextSpace.cpp
@@ -61,3 +61,15 @@ bool FTextSpace::IsEmpty() const
 {
 	return this->MaxLength == 0;
 }
+
+FString FTextSpace::ToString() const
+{
+	FString CharsetDisplay = Charset;
+	if (CharsetDisplay.Len() > 64)
+	{
+		CharsetDisplay = CharsetDisplay.Left(64).Append(TEXT("..."));
+	}
+	CharsetDisplay.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+	CharsetDisplay.ReplaceInline(TEXT("\""), TEXT("\\\""));
+	return FString::Printf(TEXT("TextSpace(MinLength=%d, MaxLength=%d, Charset=\"%s\")"), MinLength, MaxLength, *CharsetDisplay);
+}

--- a/Source/Schola/Private/Test/Points/Blueprint/PointBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Points/Blueprint/PointBlueprintLibraryTest.cpp
@@ -9,6 +9,7 @@
 #include "Points/DictPoint.h"
 #include "Points/TextPoint.h"
 #include "Common/InstancedStructUtils.h"
+#include "Math/Vector.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
 
@@ -201,6 +202,127 @@ bool FPointBlueprintLibrary_IsOfType_TextTrueTest::RunTest(const FString& Parame
     bool Result = UPointBlueprintLibrary::Point_IsOfType(ToUntypedInstancedStruct(Point), EPointType::Text);
 
     TestTrue(TEXT("Point_IsOfType(TextPoint, Text) == true"), Result);
+
+    return true;
+}
+
+// PointToString Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_InvalidTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.Invalid", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_InvalidTest::RunTest(const FString& Parameters)
+{
+    FInstancedStruct Invalid;
+    TestFalse(TEXT("Uninitialized instanced struct is invalid"), Invalid.IsValid());
+
+    FString Result = UPointBlueprintLibrary::PointToString(Invalid);
+    TestTrue(TEXT("PointToString(invalid) returns empty"), Result.IsEmpty());
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_NonPointStructTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.NonPointStruct", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_NonPointStructTest::RunTest(const FString& Parameters)
+{
+    FInstancedStruct NotAPoint;
+    NotAPoint.InitializeAs<FVector>(FVector(1.0f, 2.0f, 3.0f));
+
+    FString Result = UPointBlueprintLibrary::PointToString(NotAPoint);
+    TestTrue(TEXT("PointToString(non-FPoint struct) returns empty"), Result.IsEmpty());
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_DiscreteMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.DiscreteMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_DiscreteMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FDiscretePoint>(42);
+
+    const FString Expected = Point.Get<FDiscretePoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(Discrete) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_TextMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.TextMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_TextMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FTextPoint>(FString(TEXT("hello")));
+
+    const FString Expected = Point.Get<FTextPoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(Text) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_BoxMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.BoxMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_BoxMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FBoxPoint>();
+    Point.GetMutable<FBoxPoint>().Add(3.5f);
+
+    const FString Expected = Point.Get<FBoxPoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(Box) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_MultiBinaryMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.MultiBinaryMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_MultiBinaryMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FMultiBinaryPoint>();
+    Point.GetMutable<FMultiBinaryPoint>().Values = {true, false, true};
+
+    const FString Expected = Point.Get<FMultiBinaryPoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(MultiBinary) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_MultiDiscreteMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.MultiDiscreteMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_MultiDiscreteMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FMultiDiscretePoint>();
+    Point.GetMutable<FMultiDiscretePoint>().Values = {1, 2, 3};
+
+    const FString Expected = Point.Get<FMultiDiscretePoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(MultiDiscrete) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FPointBlueprintLibrary_PointToString_DictMatchesNativeTest, "Schola.Points.Blueprint.PointBlueprintLibrary.PointToString.DictMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPointBlueprintLibrary_PointToString_DictMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FPoint> Point;
+    Point.InitializeAs<FDictPoint>();
+
+    const FString Expected = Point.Get<FDictPoint>().ToString();
+    const FString Result = UPointBlueprintLibrary::PointToString(ToUntypedInstancedStruct(Point));
+
+    TestEqual(TEXT("PointToString(Dict) matches native ToString"), Result, Expected);
 
     return true;
 }

--- a/Source/Schola/Private/Test/Points/BoxPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/BoxPointTest.cpp
@@ -126,5 +126,14 @@ bool FBoxPointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FBoxPointToStringTest, "Schola.Points.BoxPoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FBoxPointToStringTest::RunTest(const FString& Parameters)
+{
+	const FBoxPoint BoxPoint({1.5f, 2.0f});
+	TestEqual(TEXT("FBoxPoint::ToString bracketed SanitizeFloat values"), BoxPoint.ToString(), FString(TEXT("[1.5, 2.0]")));
+	return true;
+}
+
 
 #endif

--- a/Source/Schola/Private/Test/Points/DictPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/DictPointTest.cpp
@@ -174,4 +174,27 @@ bool FDictPointOverwriteExistingPointTest::RunTest(const FString& Parameters)
 
     return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDictPointToStringEmptyTest, "Schola.Points.DictPoint.ToString.Empty", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDictPointToStringEmptyTest::RunTest(const FString& Parameters)
+{
+	const FDictPoint DictPoint;
+	TestEqual(TEXT("FDictPoint::ToString empty map"), DictPoint.ToString(), FString(TEXT("{\n}")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDictPointToStringSingleEntryTest, "Schola.Points.DictPoint.ToString.SingleEntry", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDictPointToStringSingleEntryTest::RunTest(const FString& Parameters)
+{
+	FDictPoint DictPoint;
+	TInstancedStruct<FPoint> Inner;
+	Inner.InitializeAs<FDiscretePoint>(7);
+	DictPoint.Points.Add(TEXT("alpha"), MoveTemp(Inner));
+
+	const FString Expected = FString(TEXT("{\n    alpha: 7,\n}"));
+	TestEqual(TEXT("FDictPoint::ToString single key"), DictPoint.ToString(), Expected);
+	return true;
+}
 #endif

--- a/Source/Schola/Private/Test/Points/DiscretePointTest.cpp
+++ b/Source/Schola/Private/Test/Points/DiscretePointTest.cpp
@@ -42,4 +42,13 @@ bool FDiscretePointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDiscretePointToStringTest, "Schola.Points.DiscretePoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDiscretePointToStringTest::RunTest(const FString& Parameters)
+{
+	const FDiscretePoint DiscretePoint(42);
+	TestEqual(TEXT("FDiscretePoint::ToString formats integer value"), DiscretePoint.ToString(), FString(TEXT("42")));
+	return true;
+}
+
 #endif

--- a/Source/Schola/Private/Test/Points/MultiBinaryPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/MultiBinaryPointTest.cpp
@@ -82,9 +82,9 @@ bool FMultiBinaryPointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiBinaryPointToStringTest, "Schola.Points.MultiBinaryPoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiBinaryPointToStringWithValuesTest, "Schola.Points.MultiBinaryPoint.ToString.WithValues", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
-bool FMultiBinaryPointToStringTest::RunTest(const FString& Parameters)
+bool FMultiBinaryPointToStringWithValuesTest::RunTest(const FString& Parameters)
 {
 	FMultiBinaryPoint MultiBinaryPoint;
 	MultiBinaryPoint.Values = {true, false, true};

--- a/Source/Schola/Private/Test/Points/MultiBinaryPointTest.cpp
+++ b/Source/Schola/Private/Test/Points/MultiBinaryPointTest.cpp
@@ -82,5 +82,24 @@ bool FMultiBinaryPointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiBinaryPointToStringTest, "Schola.Points.MultiBinaryPoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiBinaryPointToStringTest::RunTest(const FString& Parameters)
+{
+	FMultiBinaryPoint MultiBinaryPoint;
+	MultiBinaryPoint.Values = {true, false, true};
+	TestEqual(TEXT("FMultiBinaryPoint::ToString lists bools as true/false"), MultiBinaryPoint.ToString(), FString(TEXT("[true, false, true]")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiBinaryPointToStringEmptyTest, "Schola.Points.MultiBinaryPoint.ToString.Empty", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiBinaryPointToStringEmptyTest::RunTest(const FString& Parameters)
+{
+	const FMultiBinaryPoint MultiBinaryPoint;
+	TestEqual(TEXT("FMultiBinaryPoint::ToString with no values"), MultiBinaryPoint.ToString(), FString(TEXT("[]")));
+	return true;
+}
+
 
 #endif

--- a/Source/Schola/Private/Test/Points/MultiDiscretePointTest.cpp
+++ b/Source/Schola/Private/Test/Points/MultiDiscretePointTest.cpp
@@ -78,9 +78,9 @@ bool FMultiDiscretePointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiDiscretePointToStringTest, "Schola.Points.MultiDiscretePoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiDiscretePointToStringWithValuesTest, "Schola.Points.MultiDiscretePoint.ToString.WithValues", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
-bool FMultiDiscretePointToStringTest::RunTest(const FString& Parameters)
+bool FMultiDiscretePointToStringWithValuesTest::RunTest(const FString& Parameters)
 {
 	FMultiDiscretePoint DiscretePoint;
 	DiscretePoint.Values = {1, 2, 3};

--- a/Source/Schola/Private/Test/Points/MultiDiscretePointTest.cpp
+++ b/Source/Schola/Private/Test/Points/MultiDiscretePointTest.cpp
@@ -78,4 +78,23 @@ bool FMultiDiscretePointResetTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiDiscretePointToStringTest, "Schola.Points.MultiDiscretePoint.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiDiscretePointToStringTest::RunTest(const FString& Parameters)
+{
+	FMultiDiscretePoint DiscretePoint;
+	DiscretePoint.Values = {1, 2, 3};
+	TestEqual(TEXT("FMultiDiscretePoint::ToString bracketed integers"), DiscretePoint.ToString(), FString(TEXT("[1, 2, 3]")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiDiscretePointToStringEmptyTest, "Schola.Points.MultiDiscretePoint.ToString.Empty", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiDiscretePointToStringEmptyTest::RunTest(const FString& Parameters)
+{
+	const FMultiDiscretePoint DiscretePoint;
+	TestEqual(TEXT("FMultiDiscretePoint::ToString empty is empty brackets"), DiscretePoint.ToString(), FString(TEXT("[]")));
+	return true;
+}
+
 #endif

--- a/Source/Schola/Private/Test/Spaces/Blueprint/SpaceBlueprintLibraryTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/Blueprint/SpaceBlueprintLibraryTest.cpp
@@ -9,6 +9,7 @@
 #include "Spaces/DictSpace.h"
 #include "Spaces/TextSpace.h"
 #include "Common/InstancedStructUtils.h"
+#include "Math/Vector.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
 
@@ -201,6 +202,127 @@ bool FSpaceBlueprintLibrary_IsOfType_TextTrueTest::RunTest(const FString& Parame
     bool Result = USpaceBlueprintLibrary::Space_IsOfType(ToUntypedInstancedStruct(Space), ESpaceType::Text);
 
     TestTrue(TEXT("Space_IsOfType(TextSpace, Text) == true"), Result);
+
+    return true;
+}
+
+// SpaceToString Tests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_InvalidTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.Invalid", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_InvalidTest::RunTest(const FString& Parameters)
+{
+    FInstancedStruct Invalid;
+    TestFalse(TEXT("Uninitialized instanced struct is invalid"), Invalid.IsValid());
+
+    FString Result = USpaceBlueprintLibrary::SpaceToString(Invalid);
+    TestTrue(TEXT("SpaceToString(invalid) returns empty"), Result.IsEmpty());
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_NonSpaceStructTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.NonSpaceStruct", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_NonSpaceStructTest::RunTest(const FString& Parameters)
+{
+    FInstancedStruct NotASpace;
+    NotASpace.InitializeAs<FVector>(FVector(1.0f, 2.0f, 3.0f));
+
+    FString Result = USpaceBlueprintLibrary::SpaceToString(NotASpace);
+    TestTrue(TEXT("SpaceToString(non-FSpace struct) returns empty"), Result.IsEmpty());
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_DiscreteMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.DiscreteMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_DiscreteMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FDiscreteSpace>();
+    Space.GetMutable<FDiscreteSpace>().High = 10;
+
+    const FString Expected = Space.Get<FDiscreteSpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(Discrete) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_TextMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.TextMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_TextMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FTextSpace>(16);
+
+    const FString Expected = Space.Get<FTextSpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(Text) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_BoxMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.BoxMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_BoxMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FBoxSpace>();
+    Space.GetMutable<FBoxSpace>().Add(-1.0f, 1.0f);
+
+    const FString Expected = Space.Get<FBoxSpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(Box) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_MultiBinaryMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.MultiBinaryMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_MultiBinaryMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FMultiBinarySpace>();
+    Space.GetMutable<FMultiBinarySpace>().Shape = 4;
+
+    const FString Expected = Space.Get<FMultiBinarySpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(MultiBinary) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_MultiDiscreteMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.MultiDiscreteMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_MultiDiscreteMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FMultiDiscreteSpace>(TArray<int32>{2, 3, 4});
+
+    const FString Expected = Space.Get<FMultiDiscreteSpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(MultiDiscrete) matches native ToString"), Result, Expected);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSpaceBlueprintLibrary_SpaceToString_DictMatchesNativeTest, "Schola.Spaces.Blueprint.SpaceBlueprintLibrary.SpaceToString.DictMatchesNative", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSpaceBlueprintLibrary_SpaceToString_DictMatchesNativeTest::RunTest(const FString& Parameters)
+{
+    TInstancedStruct<FSpace> Space;
+    Space.InitializeAs<FDictSpace>();
+
+    const FString Expected = Space.Get<FDictSpace>().ToString();
+    const FString Result = USpaceBlueprintLibrary::SpaceToString(ToUntypedInstancedStruct(Space));
+
+    TestEqual(TEXT("SpaceToString(Dict) matches native ToString"), Result, Expected);
 
     return true;
 }

--- a/Source/Schola/Private/Test/Spaces/BoxSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/BoxSpaceTest.cpp
@@ -322,4 +322,35 @@ bool FBoxSpaceValidateWrongDataTypeTest::RunTest(const FString& Parameters)
 
     return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FBoxSpaceToStringNoShapeTest, "Schola.Spaces.BoxSpace.ToString.NoShape", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FBoxSpaceToStringNoShapeTest::RunTest(const FString& Parameters)
+{
+	FBoxSpace BoxSpace;
+	BoxSpace.Add(-1.0f, 1.0f);
+	BoxSpace.Add(-2.0f, 2.0f);
+
+	TestEqual(
+		TEXT("FBoxSpace::ToString without shape"),
+		BoxSpace.ToString(),
+		FString(TEXT("BoxSpace(Dimensions={[-1, 1], [-2, 2]})")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FBoxSpaceToStringWithShapeTest, "Schola.Spaces.BoxSpace.ToString.WithShape", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FBoxSpaceToStringWithShapeTest::RunTest(const FString& Parameters)
+{
+	TArray<float> Low = {-1.0f, -2.0f};
+	TArray<float> High = {1.0f, 2.0f};
+	TArray<int> Shape = {2};
+	FBoxSpace BoxSpace(Low, High, Shape);
+
+	TestEqual(
+		TEXT("FBoxSpace::ToString with shape"),
+		BoxSpace.ToString(),
+		FString(TEXT("BoxSpace(Dimensions={[-1, 1], [-2, 2]}, Shape=[2])")));
+	return true;
+}
 #endif

--- a/Source/Schola/Private/Test/Spaces/DictSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/DictSpaceTest.cpp
@@ -3,6 +3,7 @@
 #include "Misc/AutomationTest.h"
 
 #include "Spaces/DictSpace.h"
+#include "Spaces/DiscreteSpace.h"
 #include "Spaces/BoxSpace.h"
 #include "Spaces/Space.h"
 #include "Points/BoxPoint.h"
@@ -159,6 +160,31 @@ bool FDictSpaceValidateWrongDimensionsKeysMismatchTest::RunTest(const FString& P
 
 	TestEqual(TEXT("DictSpace.Validate(Point) == ESpaceValidationResult::WrongDimensions when point keys do not match space keys"), DictSpace.Validate(Point), ESpaceValidationResult::WrongDimensions);
 
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDictSpaceToStringEmptyTest, "Schola.Spaces.DictSpace.ToString.Empty", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDictSpaceToStringEmptyTest::RunTest(const FString& Parameters)
+{
+	const FDictSpace DictSpace;
+	TestEqual(TEXT("FDictSpace::ToString empty"), DictSpace.ToString(), FString(TEXT("DictSpace(\n{})")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDictSpaceToStringSingleEntryTest, "Schola.Spaces.DictSpace.ToString.SingleEntry", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDictSpaceToStringSingleEntryTest::RunTest(const FString& Parameters)
+{
+	FDictSpace DictSpace;
+	FDiscreteSpace Discrete;
+	Discrete.High = 5;
+	DictSpace.Spaces.Add(TEXT("slot"), TInstancedStruct<FSpace>::Make<FDiscreteSpace>(Discrete));
+
+	TestEqual(
+		TEXT("FDictSpace::ToString single named subspace"),
+		DictSpace.ToString(),
+		FString(TEXT("DictSpace(\n{\tslot: DiscreteSpace(High=5),\n})")));
 	return true;
 }
 

--- a/Source/Schola/Private/Test/Spaces/DiscreteSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/DiscreteSpaceTest.cpp
@@ -116,4 +116,14 @@ bool FDiscreteSpaceValidateWrongDataTypeTest::RunTest(const FString& Parameters)
 
     return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDiscreteSpaceToStringTest, "Schola.Spaces.DiscreteSpace.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FDiscreteSpaceToStringTest::RunTest(const FString& Parameters)
+{
+	FDiscreteSpace DiscreteSpace;
+	DiscreteSpace.High = 10;
+	TestEqual(TEXT("FDiscreteSpace::ToString"), DiscreteSpace.ToString(), FString(TEXT("DiscreteSpace(High=10)")));
+	return true;
+}
 #endif

--- a/Source/Schola/Private/Test/Spaces/MultiBinarySpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/MultiBinarySpaceTest.cpp
@@ -92,4 +92,14 @@ bool FMultiBinarySpaceValidateWrongDimensionsTest::RunTest(const FString& Parame
 
     return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiBinarySpaceToStringTest, "Schola.Spaces.MultiBinarySpace.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiBinarySpaceToStringTest::RunTest(const FString& Parameters)
+{
+	FMultiBinarySpace MultiBinarySpace;
+	MultiBinarySpace.Shape = 8;
+	TestEqual(TEXT("FMultiBinarySpace::ToString"), MultiBinarySpace.ToString(), FString(TEXT("MultiBinarySpace(Shape=8)")));
+	return true;
+}
 #endif

--- a/Source/Schola/Private/Test/Spaces/MultiDiscreteSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/MultiDiscreteSpaceTest.cpp
@@ -238,4 +238,13 @@ bool FMultiDiscreteSpaceGetMaxValueTest::RunTest(const FString& Parameters)
 
     return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMultiDiscreteSpaceToStringTest, "Schola.Spaces.MultiDiscreteSpace.ToString", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FMultiDiscreteSpaceToStringTest::RunTest(const FString& Parameters)
+{
+	FMultiDiscreteSpace DiscreteSpace(TArray<int>{2, 3, 4});
+	TestEqual(TEXT("FMultiDiscreteSpace::ToString"), DiscreteSpace.ToString(), FString(TEXT("MultiDiscreteSpace(High=[2, 3, 4])")));
+	return true;
+}
 #endif

--- a/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
+++ b/Source/Schola/Private/Test/Spaces/TextSpaceTest.cpp
@@ -241,4 +241,16 @@ bool FTextSpaceValidateWrongDataTypeTest::RunTest(const FString& Parameters)
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTextSpaceToStringEmptyCharsetTest, "Schola.Spaces.TextSpace.ToString.EmptyCharset", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FTextSpaceToStringEmptyCharsetTest::RunTest(const FString& Parameters)
+{
+	FTextSpace TextSpace;
+	TextSpace.MinLength = 1;
+	TextSpace.MaxLength = 16;
+	TextSpace.Charset = TEXT("");
+	TestEqual(TEXT("FTextSpace::ToString empty charset"), TextSpace.ToString(), FString(TEXT("TextSpace(MinLength=1, MaxLength=16, Charset=\"\")")));
+	return true;
+}
+
 #endif

--- a/Source/Schola/Public/Points/Blueprint/PointBlueprintLibrary.h
+++ b/Source/Schola/Public/Points/Blueprint/PointBlueprintLibrary.h
@@ -7,12 +7,6 @@
 #include "Points/Point.h"
 #include "PointBlueprintLibrary.generated.h"
 
-struct FMultiBinaryPoint;
-struct FDiscretePoint;
-struct FBoxPoint;
-struct FDictPoint;
-struct FMultiDiscretePoint;
-
 /**
  * @class UPointBlueprintLibrary
  * @brief Blueprint oriented helper functions for inspecting Point InstancedStructs.
@@ -26,6 +20,7 @@ struct FMultiDiscretePoint;
  * - UMultiDiscretePointBlueprintLibrary for MultiDiscrete points
  * - UBoxPointBlueprintLibrary for Box (continuous) points
  * - UDictPointBlueprintLibrary for Dictionary points
+ * - UTextPointBlueprintLibrary for Text points
  */
 UCLASS()
 class SCHOLA_API UPointBlueprintLibrary : public UBlueprintFunctionLibrary
@@ -49,5 +44,13 @@ public:
      */
     UFUNCTION(BlueprintPure, Category="Schola|Point", meta=(DisplayName="Is Of Type (Point)", ReturnDisplayName="Is Type"))
     static bool Point_IsOfType(UPARAM(DisplayName="Point") const FInstancedStruct& InPoint, UPARAM(DisplayName="Type") EPointType InType);
+
+	/**
+	 * @brief String representation of any instanced point whose script struct derives from FPoint.
+	 * @param[in] InPoint Type-erased instanced struct holding a concrete FPoint subtype.
+	 * @return Debug string from the point's ToString(), or empty if invalid / wrong type.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Schola|Point", meta = (DisplayName = "To String (Point)", ReturnDisplayName = "String"))
+	static FString PointToString(UPARAM(DisplayName = "Point") const FInstancedStruct& InPoint);
 
 };

--- a/Source/Schola/Public/Points/BoxPoint.h
+++ b/Source/Schola/Public/Points/BoxPoint.h
@@ -138,19 +138,20 @@ struct SCHOLA_API FBoxPoint : public FPoint
 
 	/**
 	 * @brief Converts this point to a string representation.
-	 * @return A comma-separated string of the float values.
+	 * @return Bracketed list of floats, e.g. `[0, 1.5]`.
 	 */
 	FString ToString() const override
 	{
-		FString Result = TEXT("");
-		for (int i = 0; i < this->Values.Num(); i++)
+		FString Result = TEXT("[");
+		for (int i = 0; i < this->Values.Num(); ++i)
 		{
-			Result += FString::SanitizeFloat(this->Values[i]);
-			if (i != this->Values.Num() - 1)
+			if (i > 0)
 			{
 				Result += TEXT(", ");
 			}
+			Result += FString::SanitizeFloat(this->Values[i]);
 		}
+		Result += TEXT("]");
 		return Result;
-	};
+	}
 };

--- a/Source/Schola/Public/Points/DictPoint.h
+++ b/Source/Schola/Public/Points/DictPoint.h
@@ -93,20 +93,24 @@ struct FDictPoint : public FPoint
 
 	/**
 	 * @brief Converts this dictionary point to a string representation.
-	 * @return A string showing all key-value pairs in the dictionary.
+	 * @return A multi-line string with one entry per line, for example:
+	 * @code
+	 * {
+	 *     key_a: ...
+	 *     key_b: ...
+	 * }
+	 * @endcode
 	 */
 	FString ToString() const override
 	{
-		FString Result = TEXT("{");
-		int Count = 0;
+		if (Points.Num() == 0)
+		{
+			return TEXT("{\n}");
+		}
+		FString Result = TEXT("{\n");
 		for (const auto& Pair : Points)
 		{
-			if (Count > 0)
-			{
-				Result += TEXT(", ");
-			}
-			Result += FString::Printf(TEXT("%s: %s"), *Pair.Key, *Pair.Value.Get<FPoint>().ToString());
-			Count++;
+			Result += FString::Printf(TEXT("    %s: %s,\n"), *Pair.Key, *Pair.Value.Get<FPoint>().ToString());
 		}
 		Result += TEXT("}");
 		return Result;

--- a/Source/Schola/Public/Points/MultiBinaryPoint.h
+++ b/Source/Schola/Public/Points/MultiBinaryPoint.h
@@ -109,15 +109,20 @@ struct SCHOLA_API FMultiBinaryPoint : public FPoint
 
 	/**
 	 * @brief Converts this point to a string representation.
-	 * @return A string showing all boolean values.
+	 * @return Bracketed list of true/false, e.g. `[true, false]`.
 	 */
 	FString ToString() const override
 	{
-		FString Result = TEXT("BinaryPoint: ");
-		for (int i = 0; i < this->Values.Num(); i++)
+		FString Result = TEXT("[");
+		for (int i = 0; i < this->Values.Num(); ++i)
 		{
-			Result += FString::Printf(TEXT("%d "), this->Values[i]);
+			if (i > 0)
+			{
+				Result += TEXT(", ");
+			}
+			Result += this->Values[i] ? TEXT("true") : TEXT("false");
 		}
+		Result += TEXT("]");
 		return Result;
 	}
 };

--- a/Source/Schola/Public/Points/MultiDiscretePoint.h
+++ b/Source/Schola/Public/Points/MultiDiscretePoint.h
@@ -111,19 +111,20 @@ struct SCHOLA_API FMultiDiscretePoint : public FPoint
 
 	/**
 	 * @brief Converts this point to a string representation.
-	 * @return A comma-separated string of the integer values.
+	 * @return Bracketed list of integers, e.g. `[0, 1, 2]`.
 	 */
 	FString ToString() const override
 	{
-		FString Result = TEXT("");
-		for (int i = 0; i < this->Values.Num(); i++)
+		FString Result = TEXT("[");
+		for (int i = 0; i < this->Values.Num(); ++i)
 		{
-			Result += FString::Printf(TEXT("%d"), this->Values[i]);
-			if (i != this->Values.Num() - 1)
+			if (i > 0)
 			{
 				Result += TEXT(", ");
 			}
+			Result += FString::Printf(TEXT("%d"), this->Values[i]);
 		}
+		Result += TEXT("]");
 		return Result;
 	}
 };

--- a/Source/Schola/Public/Spaces/Blueprint/SpaceBlueprintLibrary.h
+++ b/Source/Schola/Public/Spaces/Blueprint/SpaceBlueprintLibrary.h
@@ -7,12 +7,6 @@
 #include "Spaces/Space.h"
 #include "SpaceBlueprintLibrary.generated.h"
 
-struct FMultiBinarySpace;
-struct FDiscreteSpace;
-struct FBoxSpace;
-struct FDictSpace;
-struct FMultiDiscreteSpace;
-
 /**
  * @class USpaceBlueprintLibrary
  * @brief Blueprint helpers for inspecting Space InstancedStructs.
@@ -26,6 +20,7 @@ struct FMultiDiscreteSpace;
  * - UMultiDiscreteSpaceBlueprintLibrary for MultiDiscrete spaces
  * - UBoxSpaceBlueprintLibrary for Box (continuous) spaces
  * - UDictSpaceBlueprintLibrary for Dictionary spaces
+ * - UTextSpaceBlueprintLibrary for Text spaces
  */
 UCLASS()
 class SCHOLA_API USpaceBlueprintLibrary : public UBlueprintFunctionLibrary
@@ -59,4 +54,12 @@ public:
      */
     UFUNCTION(BlueprintPure, Category = "Schola|Space", meta = (DisplayName = "Contains (Space, Point)", ReturnDisplayName="Contains"))
     static bool Space_Contains(UPARAM(DisplayName="Space") const FInstancedStruct& InSpace, UPARAM(DisplayName="Point") const FInstancedStruct& InPoint);
+
+	/**
+	 * @brief String representation of any instanced space whose script struct derives from FSpace.
+	 * @param[in] InSpace Type-erased instanced struct holding a concrete FSpace subtype.
+	 * @return Debug string from the space's ToString(), or empty if invalid / wrong type.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Schola|Space", meta = (DisplayName = "To String (Space)", ReturnDisplayName = "String"))
+	static FString SpaceToString(UPARAM(DisplayName = "Space") const FInstancedStruct& InSpace);
 };

--- a/Source/Schola/Public/Spaces/BoxSpace.h
+++ b/Source/Schola/Public/Spaces/BoxSpace.h
@@ -124,6 +124,11 @@ public:
 	ESpaceValidationResult Validate(const TInstancedStruct<FPoint>& Point) const override;
 
 	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
+	/**
 	 * @brief Accepts a mutable visitor for the visitor pattern.
 	 * @param[in,out] InVisitor The visitor to accept.
 	 */

--- a/Source/Schola/Public/Spaces/DictSpace.h
+++ b/Source/Schola/Public/Spaces/DictSpace.h
@@ -81,6 +81,11 @@ struct SCHOLA_API FDictSpace : public FSpace
 	ESpaceValidationResult Validate(const TInstancedStruct<FPoint>& InPoint) const override;
 
 	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
+	/**
 	 * @brief Accepts a mutable visitor for the visitor pattern.
 	 * @param[in,out] InVisitor The visitor to accept.
 	 */

--- a/Source/Schola/Public/Spaces/DiscreteSpace.h
+++ b/Source/Schola/Public/Spaces/DiscreteSpace.h
@@ -79,6 +79,11 @@ public:
 	bool IsEmpty() const override;
 
 	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
+	/**
 	 * @brief Accepts a mutable visitor for the visitor pattern.
 	 * @param[in,out] InVisitor The visitor to accept.
 	 */

--- a/Source/Schola/Public/Spaces/MultiBinarySpace.h
+++ b/Source/Schola/Public/Spaces/MultiBinarySpace.h
@@ -73,6 +73,11 @@ struct SCHOLA_API FMultiBinarySpace : public FSpace
      */
     virtual int GetFlattenedSize() const override;
 
+	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
     /**
      * @brief Accepts a mutable visitor for the visitor pattern.
      * @param[in,out] InVisitor The visitor to accept.

--- a/Source/Schola/Public/Spaces/MultiDiscreteSpace.h
+++ b/Source/Schola/Public/Spaces/MultiDiscreteSpace.h
@@ -106,6 +106,11 @@ public:
 	bool IsEmpty() const override;
 
 	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
+	/**
 	 * @brief Accepts a mutable visitor for the visitor pattern.
 	 * @param[in,out] InVisitor The visitor to accept.
 	 */

--- a/Source/Schola/Public/Spaces/Space.h
+++ b/Source/Schola/Public/Spaces/Space.h
@@ -112,6 +112,11 @@ struct SCHOLA_API FSpace
 	 */
 	virtual int GetFlattenedSize() const PURE_VIRTUAL(FSpace::GetFlattenedSize, return 0;);
 
+	/**
+	 * @brief Converts this space to a string representation.
+	 * @return A string representation of this space for debugging and logging.
+	 */
+	virtual FString ToString() const PURE_VIRTUAL(FSpace::ToString, return TEXT("Invalid Space"););
 
 	/**
 	 * @brief Virtual destructor.

--- a/Source/Schola/Public/Spaces/TextSpace.h
+++ b/Source/Schola/Public/Spaces/TextSpace.h
@@ -135,6 +135,11 @@ public:
 	bool IsEmpty() const override;
 
 	/**
+	 * @brief Converts this space to a string representation.
+	 */
+	FString ToString() const override;
+
+	/**
 	 * @brief Accepts a mutable visitor for the visitor pattern.
 	 * @param[in,out] InVisitor The visitor to accept.
 	 */

--- a/Source/unreal_test_classes.py
+++ b/Source/unreal_test_classes.py
@@ -1,6 +1,13 @@
 # Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
-"""Unreal automation test batch types shared by pytest conftest."""
+"""Unreal automation test batch types shared by pytest conftest.
+
+.. note::
+    Unreal's session report JSON can omit a test when its full path is a strict prefix of another
+    registered test (for example ``Schola.Foo.ToString`` next to ``Schola.Foo.ToString.Empty``). Pytest
+    then raises "Test not found in Unreal Engine results". Prefer sibling leaf names that are not
+    prefixes of one another (e.g. ``...ToString.WithValues`` and ``...ToString.Empty``).
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

This PR adds ToString() outputs for `FSpace`, and `TInstancedStruct<FPoint>`, `TInstancedStruct<FSpace>`. it also reformats a few `ToString()` Methods for Points to standardize and cleanup the output format.


## Type of change
- [x] New feature or enhancement

## Changes
- New `ToString()` methods for Spaces
- New Methods in Point/Space Blueprint Libraries for converting `TInstancedStruct<FPoint>`/`TInstancedStruct<FSpace>`  to strings.
- Updated output format for a few Point `ToString()` methods.

## Testing

### Unreal C++ (`Source`)

- [x] Built / recompiled the project after Unreal Engine changes
- [x] Ran relevant automation tests (editor or pytest on Windows; see CONTRIBUTING.md)

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
