### PR TITLE
fix(rllib): guarantee rllib temp env cleanup during discovery

### DIFF
--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -5,9 +5,10 @@ Script to train an rllib model using Schola.
 """
 
 import logging
+import signal
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from schola.scripts.common.settings import (
     get_activation_function,
@@ -152,6 +153,72 @@ def _make_stop_criterion(
     }
 
 
+def _discover_env_metadata(
+    args: RllibScriptSettings,
+) -> "Tuple[list, dict, Callable, Dict[str, Any]]":
+    """
+    Discover policy metadata by briefly standing up a temporary environment.
+
+    RLlib needs the agent IDs, agent types, policy mapping, and serialized
+    ``env_config`` before it can build its training config. To learn these we
+    connect to a running Unreal instance (for ``ExternalSimulator``) or launch
+    one temporarily (for executable/project simulators).
+
+    The temporary environment owns external resources (a gRPC channel and, for
+    non-external simulators, a launched Unreal process). Those resources are
+    started inside ``RayVecEnv.__init__`` itself, so cleanup must cover the case
+    where construction fails part-way (startup handshake, ``get_definition``,
+    validation, timeout, or a ``KeyboardInterrupt`` during a slow launch).
+    Mirroring the SB3 environment's ``_define_environment``, this catches the
+    failure, releases the protocol and simulator, then re-raises the original
+    exception.
+
+    Returns
+    -------
+    Tuple[list, dict, Callable, Dict[str, Any]]
+        ``(agent_ids, agent_types, policy_mapping_fn, env_config)``.
+
+    Notes
+    -----
+    This helper either returns complete discovery metadata or re-raises the
+    original exception. It never returns partial state, so training never
+    starts in a half-configured state.
+    """
+    from schola.rllib.env import RayVecEnv
+    from schola.scripts.rllib.utils import build_env_config
+
+    sim_args = args.environment_settings.simulator_settings
+    protocol_args = args.environment_settings.protocol_settings
+
+    # Space discovery: connect to a running UE instance to learn
+    # observation/action shapes.  For ExternalSimulator the UE process is
+    # already running; for other simulators we launch one temporarily.
+    primary_sim = sim_args.make()
+    discovery_protocol = protocol_args.make()
+    try:
+        tmp_env = RayVecEnv(
+            discovery_protocol,
+            primary_sim,
+            verbosity=args.logging_settings.schola_verbosity,
+        )
+        agent_ids = sorted(tmp_env.possible_agents)
+        agent_types = dict(tmp_env.agent_types)
+        policy_mapping_fn = tmp_env.make_policy_mapping_fn()
+        env_config = build_env_config(args.environment_settings, primary_sim)
+    except (Exception, KeyboardInterrupt) as e:
+        # Release the raw protocol/simulator (tmp_env may not have been bound)
+        # so a launched Unreal process is never leaked, including on Ctrl-C.
+        if isinstance(e, KeyboardInterrupt):
+            logger.info("Ctrl-C received. Shutting down gracefully;")
+            signal.signal(signal.SIGINT, signal.SIG_IGN)  # Protect cleanup phase
+        discovery_protocol.close()
+        primary_sim.stop()
+        raise
+
+    tmp_env.close()
+    return agent_ids, agent_types, policy_mapping_fn, env_config
+
+
 # forward declare here for type hinting with no load
 def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
     """
@@ -181,32 +248,17 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
     from ray.rllib.policy.policy import Policy
     from ray.rllib.core.rl_module.rl_module import RLModuleSpec, RLModule
     from ray.rllib.connectors.env_to_module import FlattenObservations
-    from schola.rllib.env import RayVecEnv
     from schola.rllib.env_runner import ScholaEnvRunner
-    from schola.scripts.rllib.utils import build_env_config
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 
     sim_args = args.environment_settings.simulator_settings
-    protocol_args = args.environment_settings.protocol_settings
     n_sim = sim_args.num_simulators
     # Run locally if we are only running one simulator
     num_env_runners = 0 if n_sim == 1 else n_sim
 
-    # Space discovery: connect to a running UE instance to learn
-    # observation/action shapes.  For ExternalSimulator the UE process is
-    # already running; for other simulators we launch one temporarily.
-    primary_sim = sim_args.make()
-    tmp_env = RayVecEnv(
-        protocol_args.make(),
-        primary_sim,
-        verbosity=args.logging_settings.schola_verbosity,
-    )
-    try:
-        agent_ids = sorted(tmp_env.possible_agents)
-        agent_types = dict(tmp_env.agent_types)
-        policy_mapping_fn = tmp_env.make_policy_mapping_fn()
-    finally:
-        tmp_env.close()
+    # Discover policy metadata + env_config via a temporary environment that is
+    # always cleaned up, even if construction fails (no leaked Unreal process).
+    agent_ids, agent_types, policy_mapping_fn, env_config = _discover_env_metadata(args)
 
     policies = {}
     for agent_id in agent_ids:
@@ -260,7 +312,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
             enable_env_runner_and_connector_v2=True,  # Enable EnvRunner
         )
         .environment(
-            env_config=build_env_config(args.environment_settings, primary_sim),
+            env_config=env_config,
         )
         .framework("torch")
         .env_runners(

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -159,30 +159,10 @@ def _discover_env_metadata(
     """
     Discover policy metadata by briefly standing up a temporary environment.
 
-    RLlib needs the agent IDs, agent types, policy mapping, and serialized
-    ``env_config`` before it can build its training config. To learn these we
-    connect to a running Unreal instance (for ``ExternalSimulator``) or launch
-    one temporarily (for executable/project simulators).
-
-    The temporary environment owns external resources (a gRPC channel and, for
-    non-external simulators, a launched Unreal process). Those resources are
-    started inside ``RayVecEnv.__init__`` itself, so cleanup must cover the case
-    where construction fails part-way (startup handshake, ``get_definition``,
-    validation, timeout, or a ``KeyboardInterrupt`` during a slow launch).
-    Mirroring the SB3 environment's ``_define_environment``, this catches the
-    failure, releases the protocol and simulator, then re-raises the original
-    exception.
-
-    Returns
-    -------
-    Tuple[list, dict, Callable, Dict[str, Any]]
-        ``(agent_ids, agent_types, policy_mapping_fn, env_config)``.
-
-    Notes
-    -----
-    This helper either returns complete discovery metadata or re-raises the
-    original exception. It never returns partial state, so training never
-    starts in a half-configured state.
+    Returns ``(agent_ids, agent_types, policy_mapping_fn, env_config)``, which
+    RLlib needs before building its training config. On any failure (including
+    ``KeyboardInterrupt``) the protocol and simulator are released before the
+    exception is re-raised, so a launched Unreal process is never leaked.
     """
     from schola.rllib.env import RayVecEnv
     from schola.scripts.rllib.utils import build_env_config


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->
Extract Rllib space discovery step logic from main into dedicated `_discover_env_metadata(args)` helper. The helper handles cleanup if an exception is thrown or a keyboard interrupt is sent during discovery, preventing the temporary Unreal Engine process form being leaked.

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Bug fix

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
Refactored the space discovery into a helper function and add exception/keyboard-interrupt handling

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->
Ran script, and verified ctrl-c prevents Unreal Engine from leaking

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`


## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
