### PR TITLE
fix(deps): declare pillow for minari

### DIFF
--- a/Resources/python/pyproject.toml
+++ b/Resources/python/pyproject.toml
@@ -73,24 +73,22 @@ sb3 = [
 
 # Dependencies for running training with RLlib.
 # * ray[rllib] is required to run training with RLlib.
-# * ray[rllib]>=2.49 is the earliest version of RLlib supporting Gymnasium>=1.1.0, and 2.54 is the latest available version.
+# * ray[rllib]>=2.49 is the earliest version of RLlib supporting Gymnasium>=1.1.0.
+# * <2.55 because ray 2.55 removed ray.init(local_mode=...), which the test suite relies on.
 rllib = [
-    "ray[rllib]>=2.49, <2.56",
+    "ray[rllib]>=2.49, <2.55",
 ]
 
 # Dependencies for collecting Minari datasets with Schola.
 # * minari[hdf5] is required to collect Minari datasets with Schola. 0.5.2 is required for MultiBinary and MultiDiscrete spaces.
 minari = [
     "minari[hdf5,create]>=0.5.2",
+    "pillow",
 ]
 
-# All dependencies (sb3, rllib, minari)
+# All dependencies (sb3, rllib, minari). 
 all = [
-    "stable-baselines3>=2.6",
-    "tqdm",
-    "rich",
-    "ray[rllib]>=2.49, <2.55",
-    "minari[hdf5,create]>=0.5.2",
+    "schola[sb3,rllib,minari]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->
Update the pyproject.toml to include dependencies that SB3 dropped in the newest version

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Other (describe below)

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
updated pyproject.toml to add pillow to minari's dependencies. This is because in the newest version of SB3, pillow is no longer required, meaning minari would no longer work

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

Created virtual environment and ran the python tests below, with no errors

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
