### PR TITLE
fix(rllib): stop checkpoint storage when persistence is disabled

### DIFF
--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -349,10 +349,18 @@ class CheckpointSettings:
     save_final_policy: bool = False
     "Whether to save the final policy after training is complete."
 
+    @property
+    def should_persist(self) -> bool:
+        """True when any option needs artifacts written under checkpoint_dir"""
+        return self.enable_checkpoints or self.save_final_policy or self.export_onnx
+
+    @property
+    def storage_path(self) -> Optional[str]:
+        """Tune storage_path, or None to keep checkpoint_dir untouched"""
+        return str(self.checkpoint_dir.resolve()) if self.should_persist else None
+
     def __post_init__(self):
-        if (
-            self.enable_checkpoints or self.save_final_policy
-        ) and not self.checkpoint_dir.exists():
+        if self.should_persist and not self.checkpoint_dir.exists():
             self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
 

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -361,16 +361,18 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
         args.resume_settings.reset_timestep,
     )
 
+    ckpt = args.checkpoint_settings
     callbacks = []
-    try:
-        from ray.tune.logger import TBXLoggerCallback
+    if ckpt.should_persist:
+        try:
+            from ray.tune.logger import TBXLoggerCallback
 
-        callbacks.append(TBXLoggerCallback())
-    except ImportError:
-        logger.warning(
-            "tensorboardX is not installed; TensorBoard logging will be skipped. "
-            "Install tensorboardX to enable TensorBoard logging with RLlib."
-        )
+            callbacks.append(TBXLoggerCallback())
+        except ImportError:
+            logger.warning(
+                "tensorboardX is not installed; TensorBoard logging will be skipped. "
+                "Install tensorboardX to enable TensorBoard logging with RLlib."
+            )
 
     logger.info("Starting training")
     try:
@@ -380,11 +382,9 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
             stop=stop,
             checkpoint_config=air.CheckpointConfig(
                 checkpoint_frequency=(
-                    args.checkpoint_settings.save_freq
-                    if args.checkpoint_settings.enable_checkpoints
-                    else 0
+                    ckpt.save_freq if ckpt.enable_checkpoints else 0
                 ),
-                checkpoint_at_end=args.checkpoint_settings.save_final_policy,
+                checkpoint_at_end=ckpt.save_final_policy or ckpt.export_onnx,
             ),  # type: ignore
             restore=(
                 str(args.resume_settings.resume_from)
@@ -392,10 +392,12 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
                 else None
             ),
             verbose=args.logging_settings.rllib_verbosity,
-            storage_path=str(args.checkpoint_settings.checkpoint_dir.resolve()),
+            storage_path=ckpt.storage_path,
             callbacks=callbacks,
         )
-        last_checkpoint = results.get_last_checkpoint()
+        last_checkpoint = (
+            results.get_last_checkpoint() if ckpt.should_persist else None
+        )
         logger.info("Training complete")
     finally:
         # Always shutdown ray and release the environment from training even if there is an error

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -381,9 +381,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
             config=config,  # type: ignore
             stop=stop,
             checkpoint_config=air.CheckpointConfig(
-                checkpoint_frequency=(
-                    ckpt.save_freq if ckpt.enable_checkpoints else 0
-                ),
+                checkpoint_frequency=(ckpt.save_freq if ckpt.enable_checkpoints else 0),
                 checkpoint_at_end=ckpt.save_final_policy or ckpt.export_onnx,
             ),  # type: ignore
             restore=(
@@ -395,9 +393,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
             storage_path=ckpt.storage_path,
             callbacks=callbacks,
         )
-        last_checkpoint = (
-            results.get_last_checkpoint() if ckpt.should_persist else None
-        )
+        last_checkpoint = results.get_last_checkpoint() if ckpt.should_persist else None
         logger.info("Training complete")
     finally:
         # Always shutdown ray and release the environment from training even if there is an error

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -362,6 +362,11 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
     )
 
     ckpt = args.checkpoint_settings
+    if ckpt.export_onnx and not ckpt.save_final_policy:
+        logger.info(
+            "export_onnx without save_final_policy: saving an end-of-run snapshot so "
+            "the exported model matches the final training weights (writes an end-of-run checkpoint)."
+        )
     callbacks = []
     if ckpt.should_persist:
         try:


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR changes and why. -->
Updated Rllib training so it only writes Tune checkpoint storage when persistence is actually needed: checkpoints, final policy saving, or ONNX export. 


## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Bug fix

## Changes

<!-- What did you change? Call out anything reviewers should focus on. -->
Added the @property decorator in the CheckpointSettings dataclass. This lets us handle the check for persistence in one location, rather than doing it in train.py, giving us better encapsulation, making future persistence changes easier to maintain. 

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->
Created minimal Schola UE training environment and ran training script with different flags to test changes

### Python (`Resources/python`, `Test`)
- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
