### PR TITLE
fix(inference): Removed a copy from BatchedThink

### DIFF
--- a/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.cpp
+++ b/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Test/Policies/PassthroughBoxPolicy.h"
+
+#include "Points/BoxPoint.h"
+
+bool UPassthroughBoxPolicy::Think(const TInstancedStruct<FPoint>& InObservations, TInstancedStruct<FPoint>& OutAction)
+{
+	const FBoxPoint* Src = InObservations.GetPtr<FBoxPoint>();
+	if (!Src)
+	{
+		return false;
+	}
+	OutAction.InitializeAs<FBoxPoint>(Src->Values, Src->Shape);
+	return true;
+}
+
+bool UPassthroughBoxPolicy::Init(const FInteractionDefinition& InPolicyDefinition)
+{
+	(void)InPolicyDefinition;
+	return true;
+}
+
+bool UPassthroughBoxPolicy::IsInferenceBusy() const
+{
+	return false;
+}

--- a/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.cpp
+++ b/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Test/Policies/PassthroughBoxPolicy.h"
 

--- a/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.h
+++ b/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "Policies/PolicyInterface.h"
+#include "PassthroughBoxPolicy.generated.h"
+
+/**
+ * Minimal policy for tests: copies FBoxPoint observations to actions.
+ * Uses the default IPolicy::BatchedThink (per-element Think).
+ */
+UCLASS()
+class UPassthroughBoxPolicy : public UObject, public IPolicy
+{
+	GENERATED_BODY()
+
+public:
+	bool Think(const TInstancedStruct<FPoint>& InObservations, TInstancedStruct<FPoint>& OutAction) override;
+	bool Init(const FInteractionDefinition& InPolicyDefinition) override;
+	bool IsInferenceBusy() const override;
+};

--- a/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.h
+++ b/Source/Schola/Private/Test/Policies/PassthroughBoxPolicy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Schola/Private/Test/Policies/PolicyInterfaceTest.cpp
+++ b/Source/Schola/Private/Test/Policies/PolicyInterfaceTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#include "Test/Policies/PassthroughBoxPolicy.h"
+
+#include "Points/BoxPoint.h"
+#include "Policies/PolicyInterface.h"
+
+#if WITH_AUTOMATION_TESTS
+
+namespace ScholaPolicyBatchedThinkTestPrivate
+{
+	static bool BoxPointsNearlyEqual(const FBoxPoint& A, const FBoxPoint& B)
+	{
+		if (A.Values.Num() != B.Values.Num() || A.Shape.Num() != B.Shape.Num())
+		{
+			return false;
+		}
+		for (int32 i = 0; i < A.Values.Num(); ++i)
+		{
+			if (!FMath::IsNearlyEqual(A.Values[i], B.Values[i]))
+			{
+				return false;
+			}
+		}
+		for (int32 i = 0; i < A.Shape.Num(); ++i)
+		{
+			if (A.Shape[i] != B.Shape[i])
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static bool ObservationMatchesAction(const TInstancedStruct<FPoint>& Obs, const TInstancedStruct<FPoint>& Act)
+	{
+		const FBoxPoint* ObsBox = Obs.GetPtr<FBoxPoint>();
+		const FBoxPoint* ActBox = Act.GetPtr<FBoxPoint>();
+		if (!ObsBox || !ActBox)
+		{
+			return false;
+		}
+		return BoxPointsNearlyEqual(*ObsBox, *ActBox);
+	}
+} // namespace ScholaPolicyBatchedThinkTestPrivate
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPolicyBatchedThinkEmptyBatchTest,
+	"Schola.Policies.IPolicy.BatchedThink Empty Batch",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPolicyBatchedThinkEmptyBatchTest::RunTest(const FString& Parameters)
+{
+	UPassthroughBoxPolicy* PolicyObj = NewObject<UPassthroughBoxPolicy>();
+	IPolicy* Policy = Cast<IPolicy>(PolicyObj);
+	TestNotNull(TEXT("Policy object"), PolicyObj);
+	TestNotNull(TEXT("IPolicy cast"), Policy);
+
+	TArray<TInstancedStruct<FPoint>> Observations;
+	TArray<TInstancedStruct<FPoint>> Actions;
+	Actions.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(TArray<float> { 99.0f }));
+
+	const bool bOk = Policy->BatchedThink(Observations, Actions);
+	TestTrue(TEXT("BatchedThink succeeds on empty observations"), bOk);
+	TestEqual(TEXT("OutActions overwritten with empty actions"), Actions.Num(), 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPolicyBatchedThinkSingleObservationTest,
+	"Schola.Policies.IPolicy.BatchedThink Single Observation",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPolicyBatchedThinkSingleObservationTest::RunTest(const FString& Parameters)
+{
+	UPassthroughBoxPolicy* PolicyObj = NewObject<UPassthroughBoxPolicy>();
+	IPolicy* Policy = Cast<IPolicy>(PolicyObj);
+
+	TArray<float> Values = { 0.25f, -1.5f, 2.0f };
+	TArray<TInstancedStruct<FPoint>> Observations;
+	Observations.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(Values));
+
+	TArray<TInstancedStruct<FPoint>> Actions;
+	const bool bOk = Policy->BatchedThink(Observations, Actions);
+	TestTrue(TEXT("BatchedThink succeeds"), bOk);
+	TestEqual(TEXT("One action per observation"), Actions.Num(), 1);
+	TestTrue(
+		TEXT("Action matches observation"),
+		ScholaPolicyBatchedThinkTestPrivate::ObservationMatchesAction(Observations[0], Actions[0]));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPolicyBatchedThinkMultipleObservationsTest,
+	"Schola.Policies.IPolicy.BatchedThink Multiple Observations",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FPolicyBatchedThinkMultipleObservationsTest::RunTest(const FString& Parameters)
+{
+	UPassthroughBoxPolicy* PolicyObj = NewObject<UPassthroughBoxPolicy>();
+	IPolicy* Policy = Cast<IPolicy>(PolicyObj);
+
+	TArray<TInstancedStruct<FPoint>> Observations;
+	Observations.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(TArray<float> { 1.0f, 2.0f }));
+	Observations.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(TArray<float> { -0.5f }));
+	Observations.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(TArray<float> { 3.0f, 4.0f, 5.0f, 6.0f }));
+
+	TArray<TInstancedStruct<FPoint>> Actions;
+	Actions.Reserve(10);
+	Actions.Add(TInstancedStruct<FPoint>::Make<FBoxPoint>(TArray<float> { 123.0f }));
+
+	const bool bOk = Policy->BatchedThink(Observations, Actions);
+	TestTrue(TEXT("BatchedThink succeeds"), bOk);
+	TestEqual(TEXT("Actions resized to batch"), Actions.Num(), Observations.Num());
+
+	for (int32 i = 0; i < Observations.Num(); ++i)
+	{
+		const FString Label = FString::Printf(TEXT("Observation %d matches action"), i);
+		TestTrue(*Label, ScholaPolicyBatchedThinkTestPrivate::ObservationMatchesAction(Observations[i], Actions[i]));
+	}
+
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Schola/Public/Policies/PolicyInterface.h
+++ b/Source/Schola/Public/Policies/PolicyInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #pragma once
 
@@ -60,23 +60,18 @@ public:
      */
     virtual bool BatchedThink(const TArray<TInstancedStruct<FPoint>>& InObservations, TArray<TInstancedStruct<FPoint>>& OutActions)
     {
-        // Default implementation for batch processing of observations
-        // This will call Think for each observation in the batch
-        // and fill the OutAction array with the results.
+        // Default implementation for batch processing of observations.
+        // Pre-size the output so Think can write each action in-place without TArray growth or Add copies.
         // Implement in derived classes to add specialized batched handling.
-        TInstancedStruct<FPoint> SingleObservation;
-		TInstancedStruct<FPoint> SingleAction;
-        
-        for (const TInstancedStruct<FPoint>& Observation : InObservations)
+        OutActions.SetNum(InObservations.Num());
+        for (int32 Index = 0; Index < InObservations.Num(); ++Index)
         {
-			
-			if (!this->Think(Observation, SingleAction))
-			{
-				return false;
+            if (!this->Think(InObservations[Index], OutActions[Index]))
+            {
+                return false;
             }
-            OutActions.Add(SingleAction);
         }
-		return true;
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Removed an unnecessary copy from the default BatchedThink method.


## Type of change

- [] Refactor or internal cleanup

## Changes

Removed an unnecessary copy from the default BatchedThink method. Added Unreal Automation tests for Batched think.

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [ ] Not applicable

### Unreal C++ (`Source`)

- [ ] Built / recompiled the project after Unreal Engine changes
- [ ] Ran relevant automation tests (editor or pytest on Windows; see CONTRIBUTING.md)

## Checklist

- [ ] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [ ] Comments / docstrings added or updated where behavior is non-obvious
- [ ] README or Sphinx docs updated if user-facing behavior changed
- [ ] No unrelated changes included in this PR
- [ ] Appropriate license headers added to new files
