### PR TITLE
refactor(python): unified subcommand generation into a single generic template

### DIFF
--- a/Resources/python/schola/scripts/common/command_template.py
+++ b/Resources/python/schola/scripts/common/command_template.py
@@ -22,10 +22,12 @@ from typing import (
     TypeVar,
     Union,
 )
+from webbrowser import GenericBrowser
 
-from cyclopts import App, ArgumentCollection, Parameter
+from cyclopts import App, ArgumentCollection, Group, Parameter
 import cyclopts
 from cyclopts.argument import update_argument_collection
+from pandas.core import generic
 from schola.core.utils.dict_helpers import flatten_dict_no_prefix
 
 from schola.scripts.common.settings import (
@@ -40,113 +42,6 @@ SimulatorArgsType = Union[
     UnrealProjectSimulatorConfig,
     ExternalSimulatorConfig,
 ]
-
-
-class MetaCommand(Generic[ScriptArgsType]):
-    """
-    Factory for Cyclopts commands that bind simulator configs to a training entrypoint.
-
-    Parameters
-    ----------
-    app : cyclopts.App
-        Root CLI application.
-    args_type : type
-        Dataclass type for full script arguments.
-    main_func : callable
-        Invoked with a populated ``args_type`` instance.
-    logger : logging.Logger
-        Logger used when forwarding to ``main_func``.
-
-    Notes
-    -----
-    ``make_simulator_command`` returns closures wired into Cyclopts ``Parameter`` layouts.
-    """
-
-    def __init__(
-        self,
-        app: App,
-        args_type: Type[ScriptArgsType],
-        main_func: Callable[[ScriptArgsType], Any],
-        logger: logging.Logger,
-    ):
-        self.app = app
-        self.args_type = args_type
-        self._main_func = main_func
-        self._logger = logger
-
-    def make_simulator_command(self, simulator_type: Type[SimulatorArgsType]):
-        SimulatorType = NewType("SimulatorType", simulator_type)  # type: ignore
-        ArgsType = NewType("ArgsType", self.args_type)  # type: ignore
-        _main_func = self._main_func
-        if not issubclass(simulator_type, ExternalSimulatorConfig):
-            # When all dataclass fields have defaults (e.g. ExternalSimulatorConfig),
-            # cyclopts requires the parameter itself to carry a default value.
-            try:
-                _sim_default = simulator_type()
-            except TypeError:
-                _sim_default = None
-
-            if _sim_default is not None:
-
-                def completed_simulator_command(
-                    simulator_args: Annotated[SimulatorType, Parameter(name="*")] = _sim_default,  # type: ignore
-                    *,
-                    hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
-                ):
-                    hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
-                    self._logger.debug("Arguments: %s", hidden_script_args)
-                    return _main_func(hidden_script_args)
-
-            else:
-
-                def completed_simulator_command(
-                    simulator_args: Annotated[SimulatorType, Parameter(name="*")],
-                    *,
-                    hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
-                ):
-                    hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
-                    self._logger.debug("Arguments: %s", hidden_script_args)
-                    return _main_func(hidden_script_args)
-
-            return completed_simulator_command
-        else:
-
-            def completed_editor_command(
-                *,
-                hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
-            ):
-                hidden_script_args.environment_settings.simulator_settings = (
-                    ExternalSimulatorConfig()
-                )  # type: ignore
-                self._logger.debug("Arguments: %s", hidden_script_args)
-                return_value = _main_func(hidden_script_args)
-                return return_value
-
-            return completed_editor_command
-
-    @property
-    def simulator_table(self) -> Dict[str, Type[SimulatorArgsType]]:
-        return {
-            "executable": UnrealExecutableSimulatorConfig,
-            "project": UnrealProjectSimulatorConfig,
-            "external": ExternalSimulatorConfig,
-        }
-
-    @property
-    def simulator_help(self) -> Dict[str, str]:
-        return {
-            "executable": "Run Unreal from a pre-built executable.",
-            "project": "Build and Run Unreal from a UProject File.",
-            "external": "Connect to an externally managed UE process (e.g. Unreal Editor, Kubernetes pod, remote host). Default if no simulator is provided.",
-        }
-
-    @property
-    def simulator_aliases(self) -> Dict[str, str | Iterable[str] | None]:
-        return {
-            "external": "editor",
-            "project": None,
-            "executable": None,
-        }
 
 
 def load_yaml_file(file_path: Path, logger: logging.Logger) -> Dict[str, Any]:
@@ -212,27 +107,120 @@ class _ScholaConfig(cyclopts.config.Dict):
         )
 
 
-class MetaAlgCommand(MetaCommand[ScriptArgsType]):
+class ScholaCommandTemplate(Generic[ScriptArgsType]):
     """
-    ``MetaCommand`` that nests one Cyclopts sub-app per supported RL algorithm.
+    Template for creating Schola commands, that have a variable number of algorithms and simulators. These are remapped into subcommands to
+    allow for proper parsing without dumping all the arguments into the main function.
+
+    Parameters
+    ----------
+    app : App
+        The main app to add subcommands to.
+    args_type : Type[ScriptArgsType]
+        The type of the script arguments.
+    main_func : Callable[[ScriptArgsType], Any]
+        The main function to call when the command is executed.
+    logger : logging.Logger
+        The logger to use for logging.
 
     Notes
     -----
-    Subclasses implement ``algorithm_table`` and ``algorithm_help`` to list backends.
+    If any algorithms are set in the algorithm table, then the template will create a subcommand for each algorithm first before repeating for simulators.
     """
+
+    def __init__(
+        self,
+        app: App,
+        args_type: Type[ScriptArgsType],
+        main_func: Callable[[ScriptArgsType], Any],
+        logger: logging.Logger,
+    ):
+        self.app = app
+        self.args_type = args_type
+        self._main_func = main_func
+        self._logger = logger
+
+    @property
+    def simulator_table(self) -> Dict[str, Type[SimulatorArgsType]]:
+        return {
+            "executable": UnrealExecutableSimulatorConfig,
+            "project": UnrealProjectSimulatorConfig,
+            "external": ExternalSimulatorConfig,
+        }
+
+    @property
+    def simulator_help(self) -> Dict[str, str]:
+        return {
+            "executable": "Run Unreal from a pre-built executable.",
+            "project": "Build and Run Unreal from a UProject File.",
+            "external": "Connect to an externally managed UE process (e.g. Unreal Editor, Kubernetes pod, remote host). Default if no simulator is provided.",
+        }
+
+    @property
+    def simulator_aliases(self) -> Dict[str, str | Iterable[str] | None]:
+        return {
+            "external": "editor",
+            "project": None,
+            "executable": None,
+        }
+
+    @property
+    def default_simulator_name(self) -> Type[SimulatorArgsType]:
+        return "external"
+
+    def make_simulator_command(self, simulator_type: Type[SimulatorArgsType]):
+        SimulatorType = NewType("SimulatorType", simulator_type)  # type: ignore
+        ArgsType = NewType("ArgsType", self.args_type)  # type: ignore
+        _main_func = self._main_func
+        try:
+            _sim_default = simulator_type()
+        except TypeError:
+            _sim_default = None
+
+        if _sim_default is not None:
+
+            def completed_simulator_command(
+                simulator_args: Annotated[SimulatorType, Parameter(name="*")] = _sim_default,  # type: ignore
+                *,
+                hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
+            ):
+                hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
+                self._logger.debug("Arguments: %s", hidden_script_args)
+                return _main_func(hidden_script_args)
+
+        else:
+
+            def completed_simulator_command(
+                simulator_args: Annotated[SimulatorType, Parameter(name="*")],
+                *,
+                hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
+            ):
+                hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
+                self._logger.debug("Arguments: %s", hidden_script_args)
+                return _main_func(hidden_script_args)
+
+        return completed_simulator_command
 
     def make_algorithm_command(
         self, algorithm_app: App, algorithm_type: Type[Any], args_type: Type[Any]
     ):
         ResolvedArgsType = NewType("ResolvedArgsType", args_type)  # type: ignore
         AlgorithmType = NewType("AlgorithmType", algorithm_type)  # type: ignore
+        _main_func = self._main_func
+        _logger = self._logger
 
-        def algorithm_meta_command(
+        def meta_algorithm_command(
             *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
             algorithm_args: Annotated[AlgorithmType, Parameter(name="*")] = algorithm_type(),  # type: ignore
             hidden_script_args: Annotated[ResolvedArgsType, Parameter(parse=False)],
             hidden_sim_config_dict: Annotated[
                 Optional[Dict[str, Any]], Parameter(parse=False)
+            ] = None,
+            config_file: Annotated[
+                Optional[cyclopts.types.ExistingYamlPath],
+                Parameter(
+                    parse=False, show=True, help="Path to a YAML configuration file."
+                ),
             ] = None,
         ):  # type: ignore
 
@@ -251,13 +239,20 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
                     ),
                 ]
 
+            # No simulator sub-apps: ``parse_args(())`` does not resolve to ``main``; call through.
+            if self.no_simulator:
+                _logger.debug("Arguments: %s", hidden_script_args)
+                return _main_func(hidden_script_args)
+
             command, bound, ignored = algorithm_app.parse_args(tokens)
             return command(*bound.args, **bound.kwargs, **additional_kwargs)
 
-        return algorithm_meta_command
+        return meta_algorithm_command
 
     def make_train_meta_command(self, args_type: Type[Any]):
         ResolvedArgsType = NewType("ResolvedArgsType", args_type)  # type: ignore
+        _main_func = self._main_func
+        _logger = self._logger
 
         def train_meta_command(
             *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
@@ -269,15 +264,41 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
                 Optional[Dict[str, Any]], Parameter(parse=False)
             ] = None,
         ):
+            # we can naively forward the hidden_sim_config_dict as we will handle the None checking when we go to actually
+            # apply it to the app
+            additional_kwargs = {
+                "hidden_script_args": script_args,
+            }
             hidden_sim_config_dict = (
                 {} if hidden_sim_config_dict is None else hidden_sim_config_dict
             )
-            additional_kwargs = {
-                "hidden_script_args": script_args,
-                "hidden_sim_config_dict": hidden_sim_config_dict,
-            }
 
+            if self.no_algorithm:
+                if self.no_simulator:
+                    # there is no extra processing to do here, we can just call the main function
+                    _logger.debug("Arguments: %s", script_args)
+                    return _main_func(script_args)
+                else:
+                    # if there is no algorithm, it's time to apply the config to the app.
+                    self.app.config = [
+                        _ScholaConfig(
+                            hidden_sim_config_dict,
+                            use_commands_as_keys=(
+                                True if self.multiple_simulators else False
+                            ),
+                            allow_unknown=False,
+                            source=f"config:environment:simulator",
+                        ),
+                    ]
+            else:
+                # forward to the algorithm command so that we use the correct subcommands as keys
+                additional_kwargs["hidden_sim_config_dict"] = hidden_sim_config_dict
+            # continue parsing
             command, bound, ignored = self.app.parse_args(tokens)
+
+            # need to drain the additional kwargs here so that the help command doesn't raise an error
+            if command == self.app.help_print:
+                return command(*bound.args, **bound.kwargs, **{})
             return command(*bound.args, **bound.kwargs, **additional_kwargs)
 
         return train_meta_command
@@ -287,17 +308,39 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
             *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
             config_file: Annotated[
                 Optional[cyclopts.types.ExistingYamlPath],
-                Parameter(parse=True, show=True),
+                Parameter(
+                    parse=True, show=True, help="Path to a YAML configuration file."
+                ),
             ] = None,
         ):
+            env_key = "environment"
+            additional_kwargs: Dict[str, Any] = {}
             config_dict = {}
             if config_file is not None:
                 config_dict = load_yaml_file(config_file, self._logger)
 
-            alg_config_dict = config_dict.pop("algorithm", {})
-            sim_config_dict = (config_dict.get("environment") or {}).pop(
-                "simulator", {}
-            )
+            # if we have a simulator, we need to extract the keys here and then forward them onwards as a hidden argument
+            # this lets us put them at the root level of the app instead of nested in the algorithm command
+            sim_config_dict: Optional[Dict[str, Any]] = None
+            if self.has_simulator:
+                sim_config_dict = config_dict.pop(env_key, {}).pop("simulator", {})
+
+            # we can naively forward the sim_config_dict as we will handle the None checking when we go to actually
+            # apply it to the app
+            if sim_config_dict:
+                additional_kwargs["hidden_sim_config_dict"] = sim_config_dict
+
+            # if we have an algorithm, we need to extract the keys here
+            if self.has_algorithm:
+                alg_config_dict = config_dict.pop("algorithm", {})
+                self.app.config = [
+                    _ScholaConfig(
+                        alg_config_dict,
+                        use_commands_as_keys=True,
+                        allow_unknown=False,
+                        source=f"config:algorithm",
+                    ),
+                ]
 
             flat_config = flatten_dict_no_prefix(config_dict)
             self.app.meta.config = [
@@ -309,20 +352,7 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
                 ),
             ]
 
-            self.app.config = [
-                _ScholaConfig(
-                    alg_config_dict,
-                    use_commands_as_keys=True,
-                    allow_unknown=False,
-                    source=f"config:algorithm",
-                ),
-            ]
-
             command, bound, ignored = self.app.meta.parse_args(tokens)
-
-            additional_kwargs = {
-                "hidden_sim_config_dict": sim_config_dict,
-            }
 
             return command(*bound.args, **bound.kwargs, **additional_kwargs)
 
@@ -334,34 +364,64 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
         # This takes the config file and adds it to the meta app to allow for the config to be aligned with the script args
         self.app.meta.meta.default(self.make_train_config_handler())
 
-        self.app.group_commands = "Algorithm (Choose One)"
         # setup the algorithm commands (e.g. PPO, SAC, etc.)
+        # inline the algorithm command if there is only one algorithm type
+        self.maybe_make_algorithm_commands(self.app)
+        return self.app.meta
+
+    def maybe_make_algorithm_commands(self, root_app: App):
+        if self.no_algorithm:
+            self.maybe_make_simulator_commands(root_app)
+        else:
+            self.make_algorithm_commands(root_app)
+
+    def make_algorithm_commands(self, root_app: App):
+        alg_group = Group("Algorithm (Choose One)", sort_key=0)
         for algorithm in self.algorithm_table:
-            algorithm_app = App(name=algorithm, group_commands="Simulator (Choose One)")
+            algorithm_app = App(
+                name=algorithm,
+                group_commands=Group("Simulator (Choose One)", sort_key=0),
+                help=self.algorithm_help[algorithm],
+            )
             algorithm_type = self.algorithm_table[algorithm]
             algorithm_app.meta.default(
                 self.make_algorithm_command(
                     algorithm_app, algorithm_type, self.args_type
                 )
             )
+            self.maybe_make_simulator_commands(algorithm_app)
 
-            for simulator_type in self.simulator_table:
-                sim_command = self.make_simulator_command(
-                    self.simulator_table[simulator_type]
-                )
-                if simulator_type == "external":
-                    algorithm_app.default(sim_command)
-                algorithm_app.command(
-                    sim_command,
-                    name=simulator_type,
-                    alias=self.simulator_aliases[simulator_type],
-                )
-                algorithm_app[simulator_type].help = self.simulator_help[simulator_type]
+            root_app.command(algorithm_app.meta, name=algorithm)
+            root_app[algorithm].group = alg_group
 
-            self.app.command(algorithm_app.meta, name=algorithm)
-            self.app[algorithm].help = self.algorithm_help[algorithm]
+    def maybe_make_simulator_commands(self, root_app: App):
+        if self.no_simulator:
+            return
+        elif self.single_simulator:
+            self.collapse_simulator_command(root_app)
+        else:
+            self.make_simulator_commands(root_app)
 
-        return self.app.meta
+    def collapse_simulator_command(self, algorithm_app: App):
+        simulator_name, simulator_type = list(self.simulator_table.items())[0]
+        sim_command = self.make_simulator_command(simulator_type)
+        algorithm_app.default(sim_command)
+        algorithm_app.command(
+            sim_command,
+            name=simulator_name,
+        )
+
+    def make_simulator_commands(self, algorithm_app: App):
+        for simulator_name, simulator_type in self.simulator_table.items():
+            sim_command = self.make_simulator_command(simulator_type)
+            if simulator_name == self.default_simulator_name:
+                algorithm_app.default(sim_command)
+            algorithm_app.command(
+                sim_command,
+                name=simulator_name,
+                alias=self.simulator_aliases[simulator_name],
+            )
+            algorithm_app[simulator_name].help = self.simulator_help[simulator_name]
 
     @property
     def algorithm_table(self) -> Dict[str, Type[Any]]:
@@ -371,91 +431,26 @@ class MetaAlgCommand(MetaCommand[ScriptArgsType]):
     def algorithm_help(self) -> Dict[str, str]:
         return defaultdict(str)
 
+    @property
+    def no_algorithm(self) -> bool:
+        return len(self.algorithm_table) == 0
 
-class MetaNoAlgCommand(MetaCommand[ScriptArgsType]):
-    """
-    ``MetaCommand`` variant with a flat script argument tree plus optional YAML merge.
+    @property
+    def no_simulator(self) -> bool:
+        return len(self.simulator_table) == 0
 
-    Notes
-    -----
-    Used when algorithms are not split into separate Cyclopts subcommands.
-    """
+    @property
+    def single_simulator(self) -> bool:
+        return len(self.simulator_table) == 1
 
-    def make_train_config_handler(self):
-        def train_command_config_handler(
-            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
-            config_file: Annotated[
-                Optional[cyclopts.types.ExistingYamlPath], Parameter(parse=True)
-            ] = None,
-        ):
-            config_dict = {}
-            if config_file is not None:
-                config_dict = load_yaml_file(config_file, self._logger)
-            sim_config_dict = (config_dict.get("environment") or {}).pop(
-                "simulator", {}
-            )
-            flat_config = flatten_dict_no_prefix(config_dict)
-            self.app.meta.config = [
-                _ScholaConfig(
-                    flat_config,
-                    use_commands_as_keys=False,
-                    allow_unknown=False,
-                    source=f"config",
-                ),
-            ]
-            additional_kwargs = {
-                "hidden_sim_config_dict": sim_config_dict,
-            }
-            command, bound, ignored = self.app.meta.parse_args(tokens)
-            return command(*bound.args, **bound.kwargs, **additional_kwargs)
+    @property
+    def multiple_simulators(self) -> bool:
+        return len(self.simulator_table) > 1
 
-        return train_command_config_handler
+    @property
+    def has_simulator(self) -> bool:
+        return len(self.simulator_table) > 0
 
-    def make_train_meta_command(self, args_type: Type[Any]):
-        ResolvedArgsType = NewType("ArgsType", args_type)  # type: ignore
-
-        def train_meta_command(
-            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
-            script_args: Annotated[ResolvedArgsType, Parameter(name="*")] = args_type(),
-            hidden_sim_config_dict: Annotated[
-                Optional[Dict[str, Any]], Parameter(parse=False)
-            ] = None,
-        ):  # type: ignore
-            hidden_sim_config_dict = hidden_sim_config_dict or {}
-            self.app.config = [
-                _ScholaConfig(
-                    hidden_sim_config_dict,
-                    use_commands_as_keys=True,
-                    allow_unknown=False,
-                    source="config:environment:simulator",
-                ),
-            ]
-            additional_kwargs = {
-                "hidden_script_args": script_args,
-            }
-
-            command, bound, ignored = self.app.parse_args(tokens)
-            return command(*bound.args, **bound.kwargs, **additional_kwargs)
-
-        return train_meta_command
-
-    def make(self):
-        self.app.meta.default(self.make_train_meta_command(self.args_type))
-        self.app.meta.meta.default(self.make_train_config_handler())
-
-        self.app.group_commands = "Simulator (Choose One)"
-
-        for simulator_type in self.simulator_table:
-            sim_command = self.make_simulator_command(
-                self.simulator_table[simulator_type]
-            )
-            if simulator_type == "external":
-                self.app.default(sim_command)
-            self.app.command(
-                sim_command,
-                name=simulator_type,
-                alias=self.simulator_aliases[simulator_type],
-            )
-            self.app[simulator_type].help = self.simulator_help[simulator_type]
-
-        return self.app.meta
+    @property
+    def has_algorithm(self) -> bool:
+        return len(self.algorithm_table) > 0

--- a/Resources/python/schola/scripts/minari/collect.py
+++ b/Resources/python/schola/scripts/minari/collect.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 from typing_extensions import Annotated
 
-from schola.scripts.common.command_template import MetaNoAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 from schola.scripts.minari.settings import MinariScriptSettings
 from cyclopts import App, Parameter
 
@@ -127,8 +127,17 @@ _collect_app = App(
 )
 
 
-collect_app = MetaNoAlgCommand(_collect_app, MinariScriptSettings, main, logger).make()
+class CollectMinariCommand(ScholaCommandTemplate[MinariScriptSettings]):
 
+    def __init__(self, app: App, logger: logging.Logger):
+        super().__init__(app, MinariScriptSettings, main, logger)
+
+    @property
+    def algorithm_table(self):
+        return {}
+
+
+collect_app = CollectMinariCommand(_collect_app, logger).make()
 
 if __name__ == "__main__":
     collect_app.meta()

--- a/Resources/python/schola/scripts/rllib/eval/eval.py
+++ b/Resources/python/schola/scripts/rllib/eval/eval.py
@@ -5,10 +5,10 @@ Evaluate a trained RLlib algorithm from a checkpoint using ``Algorithm.evaluate`
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 from cyclopts import App
-from schola.scripts.common.command_template import MetaNoAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 from schola.scripts.rllib.eval.settings import RllibEvalScriptSettings
 
 if not logging.getLogger().handlers:
@@ -120,10 +120,11 @@ def main(args: RllibEvalScriptSettings) -> Dict[str, Any]:
 app = App(name="eval", help="Evaluate a trained RLlib policy from a checkpoint")
 
 
-class RllibEvalCommand(MetaNoAlgCommand[RllibEvalScriptSettings]):
-    """Cyclopts wiring for ``schola rllib eval``."""
+class RllibEvalCommand(ScholaCommandTemplate[RllibEvalScriptSettings]):
 
-    pass
+    @property
+    def algorithm_table(self) -> Dict[str, Type[Any]]:
+        return {}
 
 
 app = RllibEvalCommand(app, RllibEvalScriptSettings, main, logger).make()

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 from schola.scripts.common.settings import (
     get_activation_function,
 )
-from schola.scripts.common.command_template import MetaAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 
 from schola.scripts.rllib.settings import (
     APPOSettings,
@@ -419,13 +419,13 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
     return results
 
 
-class RllibTrainCommand(MetaAlgCommand[RllibScriptSettings]):
+class RllibTrainCommand(ScholaCommandTemplate[RllibScriptSettings]):
     """
-    ``MetaAlgCommand`` configuration for Ray RLlib (PPO, SAC, IMPALA, APPO).
+    ``ScholaCommandTemplate`` configuration for Ray RLlib (PPO, SAC, IMPALA, APPO).
 
     See Also
     --------
-    MetaAlgCommand
+    ScholaCommandTemplate
     """
 
     @property

--- a/Resources/python/schola/scripts/sb3/eval/eval.py
+++ b/Resources/python/schola/scripts/sb3/eval/eval.py
@@ -9,7 +9,7 @@ import signal
 from typing import List, Tuple, cast, Any
 
 from cyclopts import App
-from schola.scripts.common.command_template import MetaAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 from schola.scripts.sb3.settings import BasePPOSettings, BaseSACSettings
 from schola.scripts.sb3.eval.settings import Sb3EvalScriptSettings
 
@@ -133,13 +133,13 @@ def main(args: Sb3EvalScriptSettings) -> Tuple[float, float]:
 app = App(name="eval", help="Evaluate a trained Stable-Baselines3 policy")
 
 
-class MetaEvalSB3Command(MetaAlgCommand[Sb3EvalScriptSettings]):
+class MetaEvalSB3Command(ScholaCommandTemplate[Sb3EvalScriptSettings]):
     """
     ``MetaEvalSB3Command`` configuration for Stable-Baselines3 (PPO and SAC).
 
     See Also
     --------
-    MetaAlgCommand
+    ScholaCommandTemplate
     """
 
     @property

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -20,7 +20,7 @@ from schola.scripts.common.settings import (
     ExternalSimulatorConfig,
     get_activation_function,
 )
-from schola.scripts.common.command_template import MetaAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 from schola.scripts.sb3.train.settings import (
     PPOTrainSettings,
     SACTrainSettings,
@@ -384,13 +384,13 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
 app = App(name="train", help="Train a model using StableBaselines3")
 
 
-class MetaTrainSB3Command(MetaAlgCommand[Sb3TrainScriptSettings]):
+class MetaTrainSB3Command(ScholaCommandTemplate[Sb3TrainScriptSettings]):
     """
-    ``MetaAlgCommand`` configuration for Stable-Baselines3 (PPO and SAC).
+    ``ScholaCommandTemplate`` configuration for Stable-Baselines3 (PPO and SAC).
 
     See Also
     --------
-    MetaAlgCommand
+    ScholaCommandTemplate
     """
 
     @property

--- a/Test/minari/scripts/test_minari_cli.py
+++ b/Test/minari/scripts/test_minari_cli.py
@@ -15,10 +15,11 @@ from schola.scripts.minari.settings import (
     MinariLoggingSettings,
 )
 from schola.scripts.common.settings import EnvironmentSettings, ExternalSimulatorConfig
-from schola.scripts.common.command_template import MetaNoAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 
 # CLI Mocking Tests - verify CLI argument parsing creates correct settings classes
 
+ 
 
 @pytest.fixture
 def mock_main(mocker):
@@ -31,7 +32,13 @@ def mock_app(mock_main):
     """Build a fresh app with mocked main (no global injection)."""
     app = App(name="collect", help="Collect imitation learning datasets using Minari")
     logger = logging.getLogger(__name__)
-    app = MetaNoAlgCommand(app, MinariScriptSettings, mock_main, logger).make()
+    class MetaCollectMinariCommand(ScholaCommandTemplate[MinariScriptSettings]):
+        
+        @property
+        def algorithm_table(self):
+            return {}
+
+    app = MetaCollectMinariCommand(app, MinariScriptSettings, mock_main, logger).make()
     return app.meta
 
 

--- a/Test/scripts/test_command_template.py
+++ b/Test/scripts/test_command_template.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Annotated, Any, Dict, Type, Union
 from unittest.mock import MagicMock
@@ -18,8 +18,9 @@ from schola.scripts.common.settings import (
     ExternalSimulatorConfig,
     GrpcProtocolConfig,
     UnrealExecutableSimulatorConfig,
+    UnrealProjectSimulatorConfig,
 )
-from schola.scripts.common.command_template import MetaAlgCommand, MetaNoAlgCommand
+from schola.scripts.common.command_template import ScholaCommandTemplate
 
 # --- Fake script / algorithm types (minimal stand-ins for SB3/RLlib settings) ---
 
@@ -45,30 +46,69 @@ class FakeAlgoBeta:
 
 @dataclass
 class FakeScriptSettings:
-    """Minimal script container compatible with ``MetaAlgCommand`` wiring."""
+    """Minimal script container compatible with ``ScholaCommandTemplate`` wiring."""
 
-    environment_settings: EnvironmentSettings = field(
-        default_factory=lambda: EnvironmentSettings(
-            protocol_settings=GrpcProtocolConfig(),
-        )
-    )
+    environment_settings: EnvironmentSettings = field(default_factory=EnvironmentSettings)
+
     algorithm_settings: Annotated[
         Union[FakeAlgoAlpha, FakeAlgoBeta], Parameter(show=False, parse=False)
     ] = field(default_factory=FakeAlgoAlpha)
 
+    base_level_parameter: int = 1
 
-@dataclass
-class FakeNoAlgScriptSettings:
-    """Script settings without an algorithm subcommand (``MetaNoAlgCommand``)."""
+FULL_ALGORITHM_TABLE: Dict[str, Type[Any]] = {
+    "alpha": FakeAlgoAlpha,
+    "beta": FakeAlgoBeta,
+}
+FULL_SIMULATOR_TABLE: Dict[str, Type[Any]] = {
+    "executable": UnrealExecutableSimulatorConfig,
+    "project": UnrealProjectSimulatorConfig,
+    "external": ExternalSimulatorConfig,
+}
+FULL_SIMULATOR_KEYS: tuple[str, ...] = tuple(FULL_SIMULATOR_TABLE.keys())
 
-    environment_settings: EnvironmentSettings = field(
-        default_factory=lambda: EnvironmentSettings(
-            protocol_settings=GrpcProtocolConfig(),
-        )
-    )
+
+def _make_meta_alg_command_class(
+    algorithm_keys: tuple[str, ...],
+    simulator_keys: tuple[str, ...],
+) -> Type[ScholaCommandTemplate[FakeScriptSettings]]:
+    """Build a ``ScholaCommandTemplate`` subclass with a chosen number of algorithms / simulators."""
+
+    alg_table = {k: FULL_ALGORITHM_TABLE[k] for k in algorithm_keys}
+    sim_table = {k: FULL_SIMULATOR_TABLE[k] for k in simulator_keys}
+
+    class _DynamicScholaCommandTemplate(ScholaCommandTemplate[FakeScriptSettings]):
+        @property
+        def algorithm_table(self) -> Dict[str, Type[Any]]:
+            return alg_table
+
+        @property
+        def algorithm_help(self) -> Dict[str, str]:
+            return {k: f"Test help for {k}." for k in algorithm_keys}
+
+        @property
+        def simulator_table(self) -> Dict[str, Type[Any]]:
+            return sim_table
+
+    return _DynamicScholaCommandTemplate
 
 
-class FakeMetaAlgCommand(MetaAlgCommand[FakeScriptSettings]):
+def _build_meta_alg_app(
+    mock_main: MagicMock,
+    algorithm_keys: tuple[str, ...],
+    simulator_keys: tuple[str, ...],
+    *,
+    app_name: str = "train-param",
+) -> Any:
+    app = App(name=app_name, help="Parameterized ScholaCommandTemplate tests")
+    logger = logging.getLogger(f"test_command_template.{app_name}")
+    if not logger.handlers:
+        logger.addHandler(logging.NullHandler())
+    cls = _make_meta_alg_command_class(algorithm_keys, simulator_keys)
+    return cls(app, FakeScriptSettings, mock_main, logger).make().meta
+
+
+class FakeScholaCommandTemplate(ScholaCommandTemplate[FakeScriptSettings]):
     @property
     def algorithm_table(self) -> Dict[str, Type[Any]]:
         return {
@@ -95,20 +135,31 @@ def meta_app(mock_main: MagicMock):
     app = App(name="train-fake", help="Fake train CLI for template tests")
     logger = logging.getLogger("test_command_template")
     logger.addHandler(logging.NullHandler())
-    built = FakeMetaAlgCommand(app, FakeScriptSettings, mock_main, logger).make()
+    built = FakeScholaCommandTemplate(app, FakeScriptSettings, mock_main, logger).make()
     # ``make()`` returns ``app.meta``; config YAML handling lives on ``app.meta.meta.default``.
     return built.meta
 
 
 @pytest.fixture
 def no_alg_meta_app(mock_main: MagicMock):
-    """``MetaNoAlgCommand``: entry is ``app.meta.meta`` (config handler outermost)."""
+    """``ScholaCommandTemplate`` with no algorithms: entry is ``app.meta.meta`` (config handler outermost)."""
     app = App(name="train-no-alg-fake", help="Fake no-algorithm train CLI")
     logger = logging.getLogger("test_command_template_no_alg")
     logger.addHandler(logging.NullHandler())
-    built = MetaNoAlgCommand(app, FakeNoAlgScriptSettings, mock_main, logger).make()
-    return built.meta
+    class FakeScholaCommand(ScholaCommandTemplate[FakeScriptSettings]):
+        @property
+        def simulator_table(self) -> Dict[str, Type[Any]]:
+            return {
+                "executable": UnrealExecutableSimulatorConfig,
+                "external": ExternalSimulatorConfig,
+            }
 
+        @property
+        def algorithm_table(self) -> Dict[str, Type[Any]]:
+            return {}
+
+    built = FakeScholaCommand(app, FakeScriptSettings, mock_main, logger).make()
+    return built.meta
 
 def test_yaml_split_meta_no_alg_config_handler():
     """Like ``make_train_config_handler``: only ``environment.simulator`` is removed; ``algorithm`` stays."""
@@ -132,7 +183,7 @@ def test_no_alg_cli_default_external_simulator(no_alg_meta_app, mock_main: Magic
 
     mock_main.assert_called_once()
     args = mock_main.call_args[0][0]
-    assert isinstance(args, FakeNoAlgScriptSettings)
+    assert isinstance(args, FakeScriptSettings)
     assert isinstance(
         args.environment_settings.simulator_settings, ExternalSimulatorConfig
     )
@@ -327,6 +378,284 @@ def test_config_file_without_optional_simulator_key(
     assert isinstance(args.algorithm_settings, FakeAlgoAlpha)
 
 
+_EXE_PLACEHOLDER = "__EXE_PATH__"
+
+
+@dataclass(frozen=True, slots=True)
+class MetaAlgCliTestParameters:
+    """Row for ``test_meta_alg_cli_algorithm_simulator_count_matrix``."""
+
+    case_id: str
+    algorithm_keys: tuple[str, ...]
+    simulator_keys: tuple[str, ...]
+    cli_tokens: list[str]
+    expected_sim_settings: FakeScriptSettings
+
+
+@dataclass(frozen=True, slots=True)
+class MetaAlgConfigTestParameters:
+    """Row for ``test_meta_alg_config_algorithm_simulator_count_matrix``."""
+
+    case_id: str
+    algorithm_keys: tuple[str, ...]
+    simulator_keys: tuple[str, ...]
+    config_doc: Dict[str, Any]
+    cli_tokens: list[str]
+    expected_sim_settings: FakeScriptSettings
+
+
+_META_ALG_CLI_ALGORITHM_SIMULATOR_COUNT_MATRIX: tuple[MetaAlgCliTestParameters, ...] = (
+    MetaAlgCliTestParameters(
+        case_id="0_alg_0_sim",
+        algorithm_keys=(),
+        simulator_keys=(),
+        cli_tokens=["--base-level-parameter", "2"],
+        expected_sim_settings=FakeScriptSettings(base_level_parameter=2),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="0_alg_1_sim",
+        algorithm_keys=(),
+        simulator_keys=("external",),
+        cli_tokens=[],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="0_alg_multi_sim_default_external",
+        algorithm_keys=(),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        cli_tokens=[],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="1_alg_0_sim",
+        algorithm_keys=("alpha",),
+        simulator_keys=(),
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="1_alg_1_sim",
+        algorithm_keys=("alpha",),
+        simulator_keys=("external",),
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="1_alg_multi_sim_default_external",
+        algorithm_keys=("alpha",),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="multi_alg_0_sim",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=(),
+        cli_tokens=["beta", "--beta-steps", "33"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoBeta(beta_steps=33),
+        ),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="multi_alg_1_sim",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=("external",),
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgCliTestParameters(
+        case_id="multi_alg_multi_sim_executable",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        cli_tokens=[
+            "alpha",
+            "executable",
+            "--executable-path",
+            _EXE_PLACEHOLDER,
+        ],
+        expected_sim_settings=FakeScriptSettings(
+            environment_settings=EnvironmentSettings(
+                simulator_settings=UnrealExecutableSimulatorConfig(
+                    executable_path=Path(_EXE_PLACEHOLDER),
+                ),
+            ),
+            algorithm_settings=FakeAlgoAlpha(),
+        ),
+    ),
+)
+
+
+_META_ALG_CONFIG_ALGORITHM_SIMULATOR_COUNT_MATRIX: tuple[
+    MetaAlgConfigTestParameters, ...
+] = (
+    MetaAlgConfigTestParameters(
+        case_id="cfg_0_alg_0_sim",
+        algorithm_keys=(),
+        simulator_keys=(),
+        config_doc={},
+        cli_tokens=[],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_0_alg_1_sim",
+        algorithm_keys=(),
+        simulator_keys=("external",),
+        config_doc={"environment": {"simulator": {"external": {}}}},
+        cli_tokens=[],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_0_alg_multi_sim",
+        algorithm_keys=(),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        config_doc={"environment": {"simulator": {"external": {}}}},
+        cli_tokens=["external"],
+        expected_sim_settings=FakeScriptSettings(),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_1_alg_0_sim",
+        algorithm_keys=("alpha",),
+        simulator_keys=(),
+        config_doc={"algorithm": {"alpha": {"alpha": 0.61, "extra": 4}}},
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoAlpha(alpha=0.61, extra=4),
+        ),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_1_alg_1_sim",
+        algorithm_keys=("alpha",),
+        simulator_keys=("external",),
+        config_doc={
+            "algorithm": {"alpha": {"alpha": 0.62, "extra": 5}},
+            "environment": {"simulator": {"external": {}}},
+        },
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoAlpha(alpha=0.62, extra=5),
+        ),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_1_alg_multi_sim",
+        algorithm_keys=("alpha",),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        config_doc={
+            "algorithm": {"alpha": {"alpha": 0.63, "extra": 6}},
+            "environment": {"simulator": {"external": {}}},
+        },
+        cli_tokens=["alpha", "external"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoAlpha(alpha=0.63, extra=6),
+        ),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_multi_alg_0_sim",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=(),
+        config_doc={"algorithm": {"alpha": {"alpha": 0.64, "extra": 8}}},
+        cli_tokens=["alpha"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoAlpha(alpha=0.64, extra=8),
+        ),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_multi_alg_1_sim",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=("external",),
+        config_doc={
+            "algorithm": {"beta": {"beta_steps": 55}},
+        },
+        cli_tokens=["beta"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoBeta(beta_steps=55),
+        ),
+    ),
+    MetaAlgConfigTestParameters(
+        case_id="cfg_multi_alg_multi_sim",
+        algorithm_keys=("alpha", "beta"),
+        simulator_keys=FULL_SIMULATOR_KEYS,
+        config_doc={
+            "algorithm": {"alpha": {"alpha": 0.66, "extra": 9}},
+            "environment": {"simulator": {"external": {}}},
+        },
+        cli_tokens=["alpha", "external"],
+        expected_sim_settings=FakeScriptSettings(
+            algorithm_settings=FakeAlgoAlpha(alpha=0.66, extra=9),
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _META_ALG_CLI_ALGORITHM_SIMULATOR_COUNT_MATRIX,
+    ids=lambda c: c.case_id,
+)
+def test_meta_alg_cli_algorithm_simulator_count_matrix(
+    mock_main: MagicMock,
+    tmp_path: Path,
+    case: MetaAlgCliTestParameters,
+) -> None:
+    """Every count of algorithms (0 / 1 / 2+) × simulators (0 / 1 / 3) routes to ``main`` as expected."""
+    exe = tmp_path / "FakeGame.exe"
+    exe.write_bytes(b"")
+    resolved_cli = [
+        str(exe) if t == _EXE_PLACEHOLDER else t for t in case.cli_tokens
+    ]
+    meta = _build_meta_alg_app(
+        mock_main,
+        case.algorithm_keys,
+        case.simulator_keys,
+        app_name=f"cli-{case.algorithm_keys}-{case.simulator_keys}",
+    )
+    meta(resolved_cli, result_action="return_value", exit_on_error=False)
+
+    mock_main.assert_called_once()
+    args: FakeScriptSettings = mock_main.call_args[0][0]
+    expected = case.expected_sim_settings
+    sim = expected.environment_settings.simulator_settings
+    if isinstance(sim, UnrealExecutableSimulatorConfig) and sim.executable_path == Path(
+        _EXE_PLACEHOLDER
+    ):
+        expected = replace(
+            expected,
+            environment_settings=replace(
+                expected.environment_settings,
+                simulator_settings=UnrealExecutableSimulatorConfig(
+                    executable_path=exe,
+                ),
+            ),
+        )
+    assert args == expected
+
+
+@pytest.mark.parametrize(
+    "case",
+    _META_ALG_CONFIG_ALGORITHM_SIMULATOR_COUNT_MATRIX,
+    ids=lambda c: c.case_id,
+)
+def test_meta_alg_config_algorithm_simulator_count_matrix(
+    mock_main: MagicMock,
+    tmp_path: Path,
+    case: MetaAlgConfigTestParameters,
+) -> None:
+    """``--config-file`` merges correctly for every algorithm × simulator count combination."""
+    cfg = tmp_path / "matrix.yaml"
+    cfg.write_text(yaml.safe_dump(case.config_doc), encoding="utf-8")
+    meta = _build_meta_alg_app(
+        mock_main,
+        case.algorithm_keys,
+        case.simulator_keys,
+        app_name=f"cfg-{case.algorithm_keys}-{case.simulator_keys}",
+    )
+    cli = ["--config-file", str(cfg), *case.cli_tokens]
+    meta(cli, result_action="return_value", exit_on_error=False)
+
+    mock_main.assert_called_once()
+    args: FakeScriptSettings = mock_main.call_args[0][0]
+    assert args == case.expected_sim_settings
+
+
 def _write_invalid_yaml(path: Path) -> None:
     """YAML that ``yaml.safe_load`` rejects (nested mapping on one line)."""
     path.write_text("foo: bar: baz\n", encoding="utf-8")
@@ -363,7 +692,7 @@ def test_invalid_yaml_no_alg_config_file_logs_error_with_details(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """``MetaNoAlgCommand``: invalid YAML still logs a detailed error before empty config."""
+    """``MetalgCommand`` with no algorithms: invalid YAML still logs a detailed error before empty config."""
     cfg = tmp_path / "bad_no_alg.yaml"
     _write_invalid_yaml(cfg)
 


### PR DESCRIPTION
## Summary

This PR adds a single class to handle the subcommand orchestration for schola. It generalizes support to a table of 0,1,N algorithms, and 0,1,M simulator choices.

This PR also fixes an outstanding bug where `schola sb3 train` would raise an error when trying to print help.
In addition, `--config-file` now correctly displays when calling commands of the form `schola sb3 train ppo --help` and `schola sb3 train executable --help`

## Type of change

- [x] Bug fix
- [x] Refactor or internal cleanup

## Changes

- Rebuild MetaAlgCommand from the ground up.
- Remove MetaNoAlgCommand
- Update the minari collect command to use the new command template
- Update the rllib eval to use the new command template

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
