### PR TITLE
feat(python): expose seed option for sb3 and rllib

### DIFF
--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -390,6 +390,11 @@ class EnvironmentSettings:
     )
     "Key=value reset options forwarded to the simulator on the first env.reset(). Repeat the flag to set multiple keys, e.g. --env-options.level=1 --env-options.curriculum=easy."
 
+    seed: Annotated[
+        Optional[int], Parameter(group="Environment Arguments", alias="--seed")
+    ] = None
+    "Unified random seed for simulator reset (SeedEnvironment on first reset) and framework RNG (RLlib workers / SB3 set_random_seed). If None, training uses non-deterministic randomness."
+
 
 @dataclass
 class Sb3LauncherExtension:

--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -393,7 +393,7 @@ class EnvironmentSettings:
     seed: Annotated[
         Optional[int], Parameter(group="Environment Arguments", alias="--seed")
     ] = None
-    "Unified random seed for simulator reset (SeedEnvironment on first reset) and framework RNG (RLlib workers / SB3 set_random_seed). If None, training uses non-deterministic randomness."
+    "Unified repeatable seed for simulator and framework RNG (e.g. RLlib workers). If None, SeedEnvironment is not called in Unreal, and framework RNG is left unseeded."
 
 
 @dataclass

--- a/Resources/python/schola/scripts/rllib/train/settings.py
+++ b/Resources/python/schola/scripts/rllib/train/settings.py
@@ -61,9 +61,6 @@ class TrainingSettings:
     ] = 0.99
     "The discount factor for the reinforcement learning algorithm. This is used to calculate the present value of future rewards. A value of 0.99 means that future rewards are discounted by 1% for each time step into the future. This helps to balance the importance of immediate versus future rewards in the training process. A value closer to 1.0 will prioritize future rewards more heavily, while a value closer to 0 will prioritize immediate rewards."
 
-    seed: Optional[int] = None
-    "Random seed for reproducible training. When set, RLlib seeds workers and passes the seed into environment resets (forwarded to the simulator via SeedEnvironment). If None, training uses non-deterministic randomness."
-
     @property
     def name(self) -> str:
         return "Training Settings"

--- a/Resources/python/schola/scripts/rllib/train/settings.py
+++ b/Resources/python/schola/scripts/rllib/train/settings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All Rights Reserved.
 """
 Settings dataclasses for the RLlib training command.
 """

--- a/Resources/python/schola/scripts/rllib/train/settings.py
+++ b/Resources/python/schola/scripts/rllib/train/settings.py
@@ -61,6 +61,9 @@ class TrainingSettings:
     ] = 0.99
     "The discount factor for the reinforcement learning algorithm. This is used to calculate the present value of future rewards. A value of 0.99 means that future rewards are discounted by 1% for each time step into the future. This helps to balance the importance of immediate versus future rewards in the training process. A value closer to 1.0 will prioritize future rewards more heavily, while a value closer to 0 will prioritize immediate rewards."
 
+    seed: Optional[int] = None
+    "Random seed for reproducible training. When set, RLlib seeds workers and passes the seed into environment resets (forwarded to the simulator via SeedEnvironment). If None, training uses non-deterministic randomness."
+
     @property
     def name(self) -> str:
         return "Training Settings"

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -350,6 +350,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
         )
         .debugging(
             log_level=args.logging_settings.rllib_log_level,
+            seed=args.training_settings.seed,
         )
     )  # type: ignore
 

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -350,7 +350,7 @@ def main(args: RllibScriptSettings) -> "ray.tune.ExperimentAnalysis":
         )
         .debugging(
             log_level=args.logging_settings.rllib_log_level,
-            seed=args.training_settings.seed,
+            seed=args.environment_settings.seed,
         )
     )  # type: ignore
 

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -235,6 +235,7 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
                     env=env,
                     verbose=args.logging_settings.sb3_verbosity,
                     policy_kwargs=policy_kwargs,
+                    seed=args.environment_settings.seed,
                     **asdict(args.algorithm_settings),
                 )
 
@@ -312,6 +313,9 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
             if args.environment_settings.env_options:
                 # Inherited from SB3's `set_options`
                 env.set_options(options=args.environment_settings.env_options)
+
+            if args.environment_settings.seed is not None:
+                env.seed(args.environment_settings.seed)
 
             model.learn(
                 total_timesteps=args.training_settings.timesteps,

--- a/Test/rllib/scripts/test_train_cli.py
+++ b/Test/rllib/scripts/test_train_cli.py
@@ -189,7 +189,7 @@ def test_ppo_default_arguments(mock_app, mock_main):
     assert args.training_settings.timesteps == 3000
     assert args.training_settings.learning_rate == 0.0003
     assert args.training_settings.gamma == 0.99
-    assert args.training_settings.seed is None
+    assert args.environment_settings.seed is None
 
     # Verify default simulator is external and num_simulators defaults to 1
     from schola.scripts.common.settings import ExternalSimulatorConfig
@@ -239,7 +239,7 @@ def test_ppo_seed_argument(mock_app, mock_main):
 
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
-    assert args.training_settings.seed == 42
+    assert args.environment_settings.seed == 42
 
 
 def test_ppo_custom_algorithm_parameters(mock_app, mock_main):

--- a/Test/rllib/scripts/test_train_cli.py
+++ b/Test/rllib/scripts/test_train_cli.py
@@ -189,6 +189,7 @@ def test_ppo_default_arguments(mock_app, mock_main):
     assert args.training_settings.timesteps == 3000
     assert args.training_settings.learning_rate == 0.0003
     assert args.training_settings.gamma == 0.99
+    assert args.training_settings.seed is None
 
     # Verify default simulator is external and num_simulators defaults to 1
     from schola.scripts.common.settings import ExternalSimulatorConfig
@@ -230,6 +231,15 @@ def test_ppo_custom_training_parameters(mock_app, mock_main):
     assert args.training_settings.minibatch_size == 64
     assert args.training_settings.train_batch_size_per_learner == 256
     assert args.training_settings.num_epochs == 10
+
+
+def test_ppo_seed_argument(mock_app, mock_main):
+    """Test PPO command accepts --seed for reproducible training."""
+    mock_app.meta(["ppo", "--seed", "42"], result_action="return_value")
+
+    mock_main.assert_called_once()
+    args: RllibScriptSettings = mock_main.call_args[0][0]
+    assert args.training_settings.seed == 42
 
 
 def test_ppo_custom_algorithm_parameters(mock_app, mock_main):

--- a/Test/sb3/scripts/test_train_cli.py
+++ b/Test/sb3/scripts/test_train_cli.py
@@ -105,6 +105,17 @@ def test_ppo_cli_default_args(mock_app, mock_main):
     assert args.algorithm_settings.ent_coef == 0.0
     assert args.algorithm_settings.vf_coef == 0.5
     assert args.algorithm_settings.target_kl is None
+    assert args.environment_settings.seed is None
+
+
+def test_ppo_seed_argument(mock_app, mock_main):
+    """Test PPO command accepts --seed under Environment Arguments."""
+    command, bound, _ = mock_app.parse_args(["ppo", "--seed", "42"], exit_on_error=False)
+    command(*bound.args, **bound.kwargs)
+
+    mock_main.assert_called_once()
+    args = mock_main.call_args[0][0]
+    assert args.environment_settings.seed == 42
 
 
 def test_ppo_cli_custom_args(mock_app, mock_main):

--- a/Test/sb3/scripts/test_train_main.py
+++ b/Test/sb3/scripts/test_train_main.py
@@ -103,6 +103,7 @@ def _train_args(
     algorithm_settings: PPOTrainSettings | SACTrainSettings | None = None,
     policy_kwargs_network: bool = False,
     env_options: dict[str, str] | None = None,
+    seed: int | None = None,
 ) -> Sb3TrainScriptSettings:
     ckpt_dir = tmp_path / "ckpt"
     ckpt_dir.mkdir(parents=True, exist_ok=True)
@@ -131,6 +132,7 @@ def _train_args(
         environment_settings=EnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(port=1, url="localhost"),
             env_options=env_options or {},
+            seed=seed,
         ),
         algorithm_settings=algorithm_settings or PPOTrainSettings(),
         training_settings=replace(
@@ -357,6 +359,56 @@ def test_main_skips_set_options_when_env_options_empty(
     main(make_train_args(timesteps=2, env_options={}))
 
     patch_sb3_ppo_train_deps.set_options.assert_not_called()
+
+
+def test_main_forwards_seed_to_env(patch_sb3_ppo_train_deps, make_train_args):
+    """When ``environment_settings.seed`` is set, ``main`` calls ``env.seed``."""
+    main(make_train_args(timesteps=2, seed=42))
+
+    patch_sb3_ppo_train_deps.seed.assert_called_once_with(42)
+
+
+@patch("stable_baselines3.PPO")
+@patch("schola.sb3.env.VecEnv")
+def test_main_passes_seed_to_model_constructor(mock_vec_cls, mock_ppo, tmp_path):
+    mock_env = _mock_vec_env()
+    mock_vec_cls.return_value = mock_env
+    mock_model = MagicMock()
+    mock_model.get_vec_normalize_env.return_value = None
+    mock_ppo.load.side_effect = Exception("x")
+    mock_ppo.return_value = mock_model
+
+    main(_train_args(tmp_path, timesteps=2, seed=42))
+
+    assert mock_ppo.call_args.kwargs.get("seed") == 42
+
+
+def test_main_arms_stub_env_seeds_for_reset(
+    mocker, stub_protocol_class, stub_simulator_class, tmp_path
+):
+    """``main`` seeds the vec env so the first ``reset`` forwards non-None seeds."""
+    from schola.sb3.env import VecEnv
+
+    protocol = stub_protocol_class()
+    simulator = stub_simulator_class()
+    env = VecEnv(simulator, protocol)
+    env._process_reset = MagicMock(return_value={})
+
+    mocker.patch("schola.sb3.env.VecEnv", return_value=env)
+    mock_model = MagicMock()
+    mock_model.get_vec_normalize_env.return_value = None
+    mock_ppo = mocker.patch("stable_baselines3.PPO")
+    mock_ppo.load.side_effect = Exception("no checkpoint")
+    mock_ppo.return_value = mock_model
+
+    n = stub_protocol_class.NUM_ENVS
+    main(_train_args(tmp_path, timesteps=2, seed=42))
+
+    env.reset()
+    env.protocol.send_reset_msg.assert_called_with(
+        seeds=[42 + i for i in range(n)],
+        options=[{}] * n,
+    )
 
 
 @patch("schola.sb3.env.VecEnv")


### PR DESCRIPTION
## Summary

Allow changing seed when running SB3 or RLlib training

## Related issues

None.

## Type of change

- [x] New feature or enhancement

## Changes

## Changes

- Added seed option under environment settings for both frameworks
- Added CLI tests in `Test/rllib/scripts/test_train_cli.py`.

## Testing

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`


## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
