### PR TITLE
refactor(python): enhance error CLI through dedicated error console

### DIFF
--- a/Resources/python/schola/scripts/common/panel.py
+++ b/Resources/python/schola/scripts/common/panel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All Rights Reserved.
 """Lightweight panel printing utilities for CLI scripts.
 
 Provides simple helpers to present messages (info / warning / error) using

--- a/Resources/python/schola/scripts/common/panel.py
+++ b/Resources/python/schola/scripts/common/panel.py
@@ -2,34 +2,51 @@
 """Lightweight panel printing utilities for CLI scripts.
 
 Provides simple helpers to present messages (info / warning / error) using
-Cyclopts' rich panel integration. This module intentionally excludes any
-exception hooking or context manager capture logic; scripts should decide how
-exceptions are handled explicitly.
+Cyclopts' rich panel integration. Error panels are rendered through a dedicated
+``stderr`` console so that they match the width and styling of the panels
+Cyclopts emits for its own runtime errors (Cyclopts' default ``error_formatter``
+is :func:`~cyclopts.CycloptsPanel`, which we reuse here).
+
+The consoles defined here are shared with the top-level Cyclopts ``App`` (see
+``schola.scripts.launch``) so that every panel — whether emitted by Cyclopts or
+by these helpers — is printed to the exact same console object, guaranteeing
+consistent widths.
 """
 
 from __future__ import annotations
 
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 import sys
 from rich.console import Console
 from cyclopts import CycloptsPanel
 
 __all__ = [
+    "console",
+    "error_console",
     "print_panel",
     "print_error",
     "print_warning",
     "print_info",
 ]
 
-_console = Console()
-
 STYLE_ERROR = "red"
 STYLE_WARNING = "yellow"
 STYLE_INFO = "cyan"
 
+#: Console for informational output (stdout). Shared with the Cyclopts ``App``.
+console = Console()
+
+#: Console for error output (stderr). Shared with the Cyclopts ``App`` so that
+#: our error panels are rendered identically to Cyclopts' own error panels.
+error_console = Console(stderr=True)
+
 
 def print_panel(
-    message: Union[str, Iterable[str]], *, title: str = "", style: str = STYLE_INFO
+    message: Union[str, Iterable[str]],
+    *,
+    title: str = "",
+    style: str = STYLE_INFO,
+    console_: Optional[Console] = None,
 ) -> None:
     """
     Print a panel with the given message and style.
@@ -42,10 +59,12 @@ def print_panel(
         The title of the panel, by default ""
     style : str, optional
         The style of the panel, by default STYLE_INFO
+    console_ : Console, optional
+        The console to print to. Defaults to the shared stdout ``console``.
     """
     if not isinstance(message, str):
         message = "\n".join(str(m) for m in message)
-    _console.print(
+    (console_ or console).print(
         CycloptsPanel(message=message, title=title or "Message", style=style)
     )
 
@@ -54,16 +73,17 @@ def print_error(message: Union[str, Iterable[str]]) -> None:  # noqa: D401
     """
     Print an error panel and terminate with exit code 1.
 
+    The panel is rendered with :func:`~cyclopts.CycloptsPanel` on the shared
+    ``error_console`` (stderr), matching the panels Cyclopts prints for its own
+    runtime errors.
+
     Parameters
     ----------
     message : Union[str, Iterable[str]]
         The message to print.
     """
-    print_panel(message, title="Error", style=STYLE_ERROR)
-    try:
-        sys.exit(1)
-    except SystemExit:
-        raise
+    print_panel(message, title="Error", style=STYLE_ERROR, console_=error_console)
+    sys.exit(1)
 
 
 def print_warning(message: Union[str, Iterable[str]]) -> None:  # noqa: D401

--- a/Resources/python/schola/scripts/launch.py
+++ b/Resources/python/schola/scripts/launch.py
@@ -6,13 +6,17 @@ Entry point for the ``schola`` CLI.
 
 import sys
 from cyclopts import App, Parameter, validators, group_extractors, Group
-from schola.scripts.common.panel import print_error
+from schola.scripts.common.panel import console, error_console, print_error
 
-from rich.console import Console
+from rich.traceback import install as install_rich_traceback
 
-console = Console()
+# Route uncaught tracebacks through the (stderr) error console, as recommended
+# by the Cyclopts "Rich Formatted Exceptions" cookbook.
+install_rich_traceback(console=error_console)
+
 app = App(
     console=console,
+    error_console=error_console,
     name="schola",
     help="CLI for Schola. Useful for training a model or invoking utilities",
 )
@@ -24,7 +28,7 @@ try:
 
     app.command(sb3_app, name="sb3")
 except ImportError:
-    console.print_exception()
+    error_console.print_exception()
     print_error(
         "Stable Baselines3 (SB3) is not installed. Install via:\n"
         "pip install 'stable_baselines3'\n"
@@ -35,8 +39,8 @@ try:
     from schola.scripts.rllib import rllib_app
 
     app.command(rllib_app, name="rllib")
-except ImportError as e:
-    console.print_exception()
+except ImportError:
+    error_console.print_exception()
     print_error(
         "Ray RLlib is not installed. Install via:\n"
         "pip install 'ray[rllib]'\n"
@@ -48,7 +52,7 @@ try:
 
     app.command(minari_app, name="minari")
 except ImportError:
-    console.print_exception()
+    error_console.print_exception()
     print_error(
         "Minari is not installed. Install via:\n"
         "pip install 'minari'\n"
@@ -80,9 +84,8 @@ def main():
     """
     try:
         app()
-    except Exception as e:  # keep lightweight panel reporting
-        # print_error(f"Unhandled exception: {e}")
-        console.print_exception()
+    except Exception:
+        error_console.print_exception()
         sys.exit(1)
 
 

--- a/Resources/python/schola/scripts/launch.py
+++ b/Resources/python/schola/scripts/launch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All Rights Reserved.
 
 """
 Entry point for the ``schola`` CLI.


### PR DESCRIPTION
## Summary

- The custom `print_error()` helper we had rendered its panel on a separate `Console()`.  
- Its width and box styling didn't match the error panels Cyclopts emits for its own runtime errors.  
- This PR makes the two consistent by sharing a single pair of console objects between the panel helpers and the Cyclopts App, and adopts the error-console + Rich-traceback setup recommended in the Cyclopts "Rich Formatted Exceptions" cookbook.  
- Cyclopts' default `error_formatter` is already `CycloptsPanel`, so we simply reuse it on the same console rather than maintaining a divergent one.

## Related issues

None

## Type of change

- [x] Bug fix
- [x] Refactor or internal cleanup

## Changes

`Resources/python/schola/scripts/common/panel.py`
- Replaced the single module-level `_console` with two shared, exported consoles: `console` (stdout) and `error_console` (stderr).
- `print_error()` now renders its `CycloptsPanel` on the shared `error_console`, print_warning/print_info stay on stdout.
- Added an optional `console_` parameter to `print_panel()` for routing
- Simplified the redundant `sys.exit(1)` try/except.

`Resources/python/schola/scripts/launch.py`
- Imports the shared `console/error_console` and passes both into `App(console=..., error_console=...)` so Cyclopts and the helpers print to the same objects.
- Installs Rich's traceback handler on the error console `(install_rich_traceback(console=error_console))` per the Cyclopts cookbook.
- Routed the import-error and top-level exception `print_exception()` calls to `error_console` (stderr) for consistency.

## Testing

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
