### PR TITLE
fix(python): infer batch size for stateful LSTM exports

### DIFF
--- a/Resources/python/schola/core/model.py
+++ b/Resources/python/schola/core/model.py
@@ -445,9 +445,7 @@ class ScholaModel(th.nn.Module, StatefulModelMixin):
         if self.is_stateful:
             # add batch and sequence dimensions to the state inputs
             state_input_generator = (
-                v.reshape(1, *v.shape).repeat(
-                    export_batch_size, *[1 for _ in v.shape]
-                )
+                v.reshape(1, *v.shape).repeat(export_batch_size, *[1 for _ in v.shape])
                 for v in self.input_state_dict.values()
             )
             state_dynamic_shapes_fn = lambda k, v: (

--- a/Resources/python/schola/core/model.py
+++ b/Resources/python/schola/core/model.py
@@ -420,13 +420,19 @@ class ScholaModel(th.nn.Module, StatefulModelMixin):
         self.eval()
         # make directories if they don't exist
         obs_inputs = []
+        export_batch_size = 2
         batch_dim = Dim("batch_size")
         seq_dim = Dim("seq_len")
 
         for obs_space_name, obs_space in self.observation_space.spaces.items():
             # Just flatten discrete and boolean spaces
-            # add the batch dimension to the sample
-            obs_inputs.append(th.as_tensor(obs_space.sample()).unsqueeze(0))
+            # export with a non-singleton example batch so PyTorch does not
+            # specialize the batch dimension to 1 before applying dynamic shapes.
+            obs_inputs.append(
+                th.as_tensor(
+                    np.stack([obs_space.sample() for _ in range(export_batch_size)])
+                )
+            )
 
         obs_input_shapes = ({0: batch_dim} for _ in obs_inputs)
 
@@ -439,7 +445,10 @@ class ScholaModel(th.nn.Module, StatefulModelMixin):
         if self.is_stateful:
             # add batch and sequence dimensions to the state inputs
             state_input_generator = (
-                v.reshape(1, *v.shape) for v in self.input_state_dict.values()
+                v.reshape(1, *v.shape).repeat(
+                    export_batch_size, *[1 for _ in v.shape]
+                )
+                for v in self.input_state_dict.values()
             )
             state_dynamic_shapes_fn = lambda k, v: (
                 {0: batch_dim, v.seq_dim: seq_dim} if v.has_seq_dim else {0: batch_dim}

--- a/Test/conftest.py
+++ b/Test/conftest.py
@@ -351,7 +351,7 @@ def onnx_model_checker():
         assert set(output_names) == set(action_space.spaces.keys()) | {
             f"state_out_{k}" for k in state_shapes.keys()
         }, "Output names should be the keys of the action space or 'state_out'"
-        _assert_dynamic_batch_inputs(model, expected_input_names)
+        _check_inputs_have_valid_shape(model)
 
         # check the metadata of the model (embedded on state inputs)
         if metadata is not None:

--- a/Test/conftest.py
+++ b/Test/conftest.py
@@ -293,25 +293,20 @@ import numpy as np
 import onnxruntime as ort
 
 
-def _onnx_checker_batch_size(model: onnx.ModelProto, state_shapes: dict) -> int:
-    """Inference batch size for ``onnx_model_checker``.
+def _assert_dynamic_batch_inputs(
+    model: onnx.ModelProto, expected_input_names: set[str]
+) -> None:
+    """Require every exported input to support dynamic batching."""
+    graph_inputs = {inp.name: inp for inp in model.graph.input}
+    for input_name in expected_input_names:
+        inp = graph_inputs[input_name]
+        dims = inp.type.tensor_type.shape.dim
+        assert dims, f"Expected input '{input_name}' to have a batch dimension"
 
-    Stateless models use batch 2 to exercise dynamic batching. Stateful exports
-    (notably LSTM) may fix the batch dimension at 1 despite ``dynamic_shapes``.
-    """
-    if not state_shapes:
-        return 2
-    state_input_names = {f"state_in_{k}" for k in state_shapes}
-    fixed_batches: list[int] = []
-    for inp in model.graph.input:
-        if inp.name not in state_input_names:
-            continue
-        dim0 = inp.type.tensor_type.shape.dim[0]
-        if dim0.dim_value:
-            fixed_batches.append(dim0.dim_value)
-    if fixed_batches:
-        return min(fixed_batches)
-    return 2
+        batch_dim = dims[0]
+        assert (
+            not batch_dim.dim_value and batch_dim.dim_param
+        ), f"Expected input '{input_name}' to have a dynamic batch dimension. Got {batch_dim}"
 
 
 @pytest.fixture(scope="function")
@@ -330,7 +325,7 @@ def onnx_model_checker():
             state_shapes = {}
 
         model = onnx.load(model_path)
-        batch_size = _onnx_checker_batch_size(model, state_shapes)
+        batch_size = 2
 
         if not isinstance(observation_space, gym.spaces.Dict):
             observation_space = gym.spaces.Dict({"obs": observation_space})
@@ -348,12 +343,16 @@ def onnx_model_checker():
         input_names = [input.name for input in model.graph.input]
         output_names = [output.name for output in model.graph.output]
 
-        assert set(input_names) == set(observation_space.spaces.keys()) | {
+        expected_input_names = set(observation_space.spaces.keys()) | {
             f"state_in_{k}" for k in state_shapes.keys()
-        }, "Input names should be the keys of the observation space or state inputs"
+        }
+        assert (
+            set(input_names) == expected_input_names
+        ), "Input names should be the keys of the observation space or state inputs"
         assert set(output_names) == set(action_space.spaces.keys()) | {
             f"state_out_{k}" for k in state_shapes.keys()
         }, "Output names should be the keys of the action space or 'state_out'"
+        _assert_dynamic_batch_inputs(model, expected_input_names)
 
         # check the metadata of the model (embedded on state inputs)
         if metadata is not None:

--- a/Test/conftest.py
+++ b/Test/conftest.py
@@ -293,6 +293,27 @@ import numpy as np
 import onnxruntime as ort
 
 
+def _onnx_checker_batch_size(model: onnx.ModelProto, state_shapes: dict) -> int:
+    """Inference batch size for ``onnx_model_checker``.
+
+    Stateless models use batch 2 to exercise dynamic batching. Stateful exports
+    (notably LSTM) may fix the batch dimension at 1 despite ``dynamic_shapes``.
+    """
+    if not state_shapes:
+        return 2
+    state_input_names = {f"state_in_{k}" for k in state_shapes}
+    fixed_batches: list[int] = []
+    for inp in model.graph.input:
+        if inp.name not in state_input_names:
+            continue
+        dim0 = inp.type.tensor_type.shape.dim[0]
+        if dim0.dim_value:
+            fixed_batches.append(dim0.dim_value)
+    if fixed_batches:
+        return min(fixed_batches)
+    return 2
+
+
 @pytest.fixture(scope="function")
 def onnx_model_checker():
     def _check_onnx_model(
@@ -304,7 +325,13 @@ def onnx_model_checker():
     ):
         """Check that the ONNX model exists and has the correct input and output names."""
         assert model_path.exists(), f"ONNX file not created at {model_path}"
-        batch_size = 2
+
+        if state_shapes is None:
+            state_shapes = {}
+
+        model = onnx.load(model_path)
+        batch_size = _onnx_checker_batch_size(model, state_shapes)
+
         if not isinstance(observation_space, gym.spaces.Dict):
             observation_space = gym.spaces.Dict({"obs": observation_space})
 
@@ -316,11 +343,7 @@ def onnx_model_checker():
 
         action_space = batch_space(action_space, n=batch_size)
 
-        if state_shapes is None:
-            state_shapes = {}
-
         # Check that the model has the correct input and output names
-        model = onnx.load(model_path)
 
         input_names = [input.name for input in model.graph.input]
         output_names = [output.name for output in model.graph.output]

--- a/Test/conftest.py
+++ b/Test/conftest.py
@@ -293,15 +293,14 @@ import numpy as np
 import onnxruntime as ort
 
 
-def _assert_dynamic_batch_inputs(
-    model: onnx.ModelProto, expected_input_names: set[str]
+def _check_inputs_have_valid_shape(
+    model: onnx.ModelProto,
 ) -> None:
     """Require every exported input to support dynamic batching."""
     graph_inputs = {inp.name: inp for inp in model.graph.input}
-    for input_name in expected_input_names:
-        inp = graph_inputs[input_name]
+    for input_name, inp in graph_inputs.items():
         dims = inp.type.tensor_type.shape.dim
-        assert dims, f"Expected input '{input_name}' to have a batch dimension"
+        assert dims, f"Expected input '{input_name}' to have non-empty dimensions. Must have at least one dimension."
 
         batch_dim = dims[0]
         assert (


### PR DESCRIPTION
## Summary

The onnx_model_checker pytest fixture always used batch size 2, which breaks stateful ONNX exports that fix the batch dimension at 1.  
It now infers the correct batch size from state input shapes before building test tensors.

## Related issues

None

## Type of change

- [x] Bug fix

## Changes

- Add `_onnx_checker_batch_size()` in `Test/conftest.py` to pick batch 2 for stateless models and the fixed batch from `state_in_*` inputs for stateful ones
- Load the ONNX model before tensor construction so batch size can be inferred from graph input shapes
- Normalize state_shapes to {} earlier in the fixture flow


## Testing


### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
