### PR TITLE
refactor(python): Improve typing for protocols, simulators and associated CLI Objects

### DIFF
--- a/Resources/python/schola/core/simulators/__init__.py
+++ b/Resources/python/schola/core/simulators/__init__.py
@@ -2,5 +2,6 @@
 """Simulator abstractions for launching and connecting to Unreal (editor, executable, project)."""
 
 from schola.core.simulators.external_simulator import ExternalSimulator
+from schola.core.simulators.spawn_protocol import SupportsSpawn
 
-__all__ = ["ExternalSimulator"]
+__all__ = ["ExternalSimulator", "SupportsSpawn"]

--- a/Resources/python/schola/core/simulators/spawn_protocol.py
+++ b/Resources/python/schola/core/simulators/spawn_protocol.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+"""
+Typing protocols for spawning duplicate simulator instances.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar, runtime_checkable
+
+
+S = TypeVar("S")
+
+@runtime_checkable
+class SupportsSpawn(Protocol[S]):
+    """Protocol for types that can spawn additional copies of themselves."""
+
+    def spawn(self, count: int = 1) -> list[S]:
+        """Return a list of new instances with the same configuration as ``self``."""
+        ...

--- a/Resources/python/schola/core/simulators/spawn_protocol.py
+++ b/Resources/python/schola/core/simulators/spawn_protocol.py
@@ -7,14 +7,15 @@ Typing protocols for spawning duplicate simulator instances.
 from __future__ import annotations
 
 from typing import Protocol, TypeVar, runtime_checkable
+from collections.abc import Sequence
 
+S = TypeVar("S", covariant=True)
 
-S = TypeVar("S")
 
 @runtime_checkable
 class SupportsSpawn(Protocol[S]):
     """Protocol for types that can spawn additional copies of themselves."""
 
-    def spawn(self, count: int = 1) -> list[S]:
+    def spawn(self, count: int = 1) -> Sequence[S]:
         """Return a list of new instances with the same configuration as ``self``."""
         ...

--- a/Resources/python/schola/core/simulators/unreal/base_simulator.py
+++ b/Resources/python/schola/core/simulators/unreal/base_simulator.py
@@ -3,7 +3,6 @@
 Base Class for Unreal Connections
 """
 
-
 from schola.core.protocols.async_base_protocol import AsyncBaseRLProtocol
 from schola.core.protocols.base_protocol import BaseProtocol
 from schola.core.protocols.protobuf.async_grpc_protocol import AsyncGrpcProtocol

--- a/Resources/python/schola/core/simulators/unreal/executable_simulator.py
+++ b/Resources/python/schola/core/simulators/unreal/executable_simulator.py
@@ -98,6 +98,37 @@ class UnrealExecutable(BaseUnrealSimulator):
         self.map = map
         self.extra_args = extra_args if extra_args is not None else []
 
+    def spawn(self, count: int = 1) -> list["UnrealExecutable"]:
+        """
+        Return a new UnrealExecutable with the same launch settings as this instance.
+
+        Parameters
+        ----------
+        count : int, default=1
+            Number of instances to spawn. Only ``1`` is supported; use
+            :meth:`spawn_executables` to create multiple instances.
+
+        Returns
+        -------
+        UnrealExecutable
+            A new simulator instance with the same executable path and launch options.
+
+        Raises
+        ------
+        ValueError
+            If ``count`` is not ``1``.
+        """
+        return [UnrealExecutable(
+            executable_path=self.executable_path,
+            headless_mode=self.headless_mode,
+            map=self.map,
+            display_logs=self.display_logs,
+            set_fps=self.set_fps,
+            disable_script=self.disable_script,
+            extra_args=self.extra_args.copy() if self.extra_args else None,
+            validate_path=False,
+        ) for _ in range(count)]
+
     def spawn_executable(self) -> "UnrealExecutable":
         """
         Return a new UnrealExecutable with the same launch settings as this instance.
@@ -110,16 +141,7 @@ class UnrealExecutable(BaseUnrealSimulator):
         UnrealExecutable
             A new simulator instance with the same executable path and launch options.
         """
-        return UnrealExecutable(
-            executable_path=self.executable_path,
-            headless_mode=self.headless_mode,
-            map=self.map,
-            display_logs=self.display_logs,
-            set_fps=self.set_fps,
-            disable_script=self.disable_script,
-            extra_args=self.extra_args.copy() if self.extra_args else None,
-            validate_path=False,
-        )
+        return self.spawn(1)[0]
 
     def get_executable_args(self) -> dict[str, Any]:
         """
@@ -155,7 +177,7 @@ class UnrealExecutable(BaseUnrealSimulator):
         List[UnrealExecutable]
             List of new simulator instances (none started).
         """
-        return [self.spawn_executable() for _ in range(count)]
+        return self.spawn(count)
 
     def make_args(self) -> list[str]:
         """

--- a/Resources/python/schola/core/simulators/unreal/executable_simulator.py
+++ b/Resources/python/schola/core/simulators/unreal/executable_simulator.py
@@ -100,34 +100,34 @@ class UnrealExecutable(BaseUnrealSimulator):
 
     def spawn(self, count: int = 1) -> list["UnrealExecutable"]:
         """
-        Return a new UnrealExecutable with the same launch settings as this instance.
+        Return new UnrealExecutable instances with the same launch settings as this instance.
+
+        Use this to create additional simulator instances from the same executable
+        without changing any launch options. None of the returned instances are started.
 
         Parameters
         ----------
         count : int, default=1
-            Number of instances to spawn. Only ``1`` is supported; use
-            :meth:`spawn_executables` to create multiple instances.
+            Number of instances to spawn.
 
         Returns
         -------
-        UnrealExecutable
-            A new simulator instance with the same executable path and launch options.
-
-        Raises
-        ------
-        ValueError
-            If ``count`` is not ``1``.
+        list[UnrealExecutable]
+            New simulator instances with the same executable path and launch options.
         """
-        return [UnrealExecutable(
-            executable_path=self.executable_path,
-            headless_mode=self.headless_mode,
-            map=self.map,
-            display_logs=self.display_logs,
-            set_fps=self.set_fps,
-            disable_script=self.disable_script,
-            extra_args=self.extra_args.copy() if self.extra_args else None,
-            validate_path=False,
-        ) for _ in range(count)]
+        return [
+            UnrealExecutable(
+                executable_path=self.executable_path,
+                headless_mode=self.headless_mode,
+                map=self.map,
+                display_logs=self.display_logs,
+                set_fps=self.set_fps,
+                disable_script=self.disable_script,
+                extra_args=self.extra_args.copy() if self.extra_args else None,
+                validate_path=False,
+            )
+            for _ in range(count)
+        ]
 
     def spawn_executable(self) -> "UnrealExecutable":
         """

--- a/Resources/python/schola/core/utils/dict_helpers.py
+++ b/Resources/python/schola/core/utils/dict_helpers.py
@@ -7,7 +7,6 @@ import itertools
 from collections.abc import Callable, Iterator
 from typing import TypeVar, cast
 
-
 V = TypeVar("V")
 Y = TypeVar("Y")
 K = TypeVar("K")

--- a/Resources/python/schola/scripts/common/command_template.py
+++ b/Resources/python/schola/scripts/common/command_template.py
@@ -21,7 +21,10 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
+    get_origin,
 )
+
 from webbrowser import GenericBrowser
 
 from cyclopts import App, ArgumentCollection, Group, Parameter
@@ -31,18 +34,14 @@ from pandas.core import generic
 from schola.core.utils.dict_helpers import flatten_dict_no_prefix
 
 from schola.scripts.common.settings import (
+    BaseSimulatorConfig,
     UnrealExecutableSimulatorConfig,
     UnrealProjectSimulatorConfig,
     ExternalSimulatorConfig,
 )
 
 ScriptArgsType = TypeVar("ScriptArgsType")
-SimulatorArgsType = Union[
-    UnrealExecutableSimulatorConfig,
-    UnrealProjectSimulatorConfig,
-    ExternalSimulatorConfig,
-]
-
+AlgorithmArgsType = TypeVar("AlgorithmArgsType")
 
 def load_yaml_file(file_path: Path, logger: logging.Logger) -> Dict[str, Any]:
     """
@@ -116,10 +115,6 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
     ----------
     app : App
         The main app to add subcommands to.
-    args_type : Type[ScriptArgsType]
-        The type of the script arguments.
-    main_func : Callable[[ScriptArgsType], Any]
-        The main function to call when the command is executed.
     logger : logging.Logger
         The logger to use for logging.
 
@@ -131,17 +126,15 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
     def __init__(
         self,
         app: App,
-        args_type: Type[ScriptArgsType],
-        main_func: Callable[[ScriptArgsType], Any],
         logger: logging.Logger,
     ):
         self.app = app
-        self.args_type = args_type
-        self._main_func = main_func
         self._logger = logger
 
+    
     @property
-    def simulator_table(self) -> Dict[str, Type[SimulatorArgsType]]:
+    def simulator_table(self) -> Dict[str, Type[BaseSimulatorConfig[Any]]]:
+        # Ignore the type here as it is difficult to resolve with current typing tooling
         return {
             "executable": UnrealExecutableSimulatorConfig,
             "project": UnrealProjectSimulatorConfig,
@@ -165,13 +158,20 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
         }
 
     @property
-    def default_simulator_name(self) -> Type[SimulatorArgsType]:
+    def default_simulator_name(self) -> str:
         return "external"
 
-    def make_simulator_command(self, simulator_type: Type[SimulatorArgsType]):
+    @property
+    def script_args_type(self) -> Type[ScriptArgsType]:
+        ...
+
+    @property
+    def main_func(self) -> Callable[[ScriptArgsType], Any]:
+        ...
+    
+    def make_simulator_command(self, simulator_type: Type[BaseSimulatorConfig[Any]]):
         SimulatorType = NewType("SimulatorType", simulator_type)  # type: ignore
-        ArgsType = NewType("ArgsType", self.args_type)  # type: ignore
-        _main_func = self._main_func
+        _main_func = self.main_func
         try:
             _sim_default = simulator_type()
         except TypeError:
@@ -179,40 +179,38 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
 
         if _sim_default is not None:
 
-            def completed_simulator_command(
+            def default_simulator_command(
                 simulator_args: Annotated[SimulatorType, Parameter(name="*")] = _sim_default,  # type: ignore
                 *,
-                hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
+                hidden_script_args: Annotated[ScriptArgsType, Parameter(parse=False)],
             ):
                 hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
                 self._logger.debug("Arguments: %s", hidden_script_args)
                 return _main_func(hidden_script_args)
-
+            return default_simulator_command
         else:
 
-            def completed_simulator_command(
+            def non_default_simulator_command(
                 simulator_args: Annotated[SimulatorType, Parameter(name="*")],
                 *,
-                hidden_script_args: Annotated[ArgsType, Parameter(parse=False)],
+                hidden_script_args: Annotated[ScriptArgsType, Parameter(parse=False)],
             ):
                 hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
                 self._logger.debug("Arguments: %s", hidden_script_args)
                 return _main_func(hidden_script_args)
-
-        return completed_simulator_command
+            return non_default_simulator_command
 
     def make_algorithm_command(
-        self, algorithm_app: App, algorithm_type: Type[Any], args_type: Type[Any]
+        self, algorithm_app: App, algorithm_type: Type[Any]
     ):
-        ResolvedArgsType = NewType("ResolvedArgsType", args_type)  # type: ignore
         AlgorithmType = NewType("AlgorithmType", algorithm_type)  # type: ignore
-        _main_func = self._main_func
+        _main_func = self.main_func
         _logger = self._logger
 
         def meta_algorithm_command(
             *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
             algorithm_args: Annotated[AlgorithmType, Parameter(name="*")] = algorithm_type(),  # type: ignore
-            hidden_script_args: Annotated[ResolvedArgsType, Parameter(parse=False)],
+            hidden_script_args: Annotated[ScriptArgsType, Parameter(parse=False)],
             hidden_sim_config_dict: Annotated[
                 Optional[Dict[str, Any]], Parameter(parse=False)
             ] = None,
@@ -249,17 +247,17 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
 
         return meta_algorithm_command
 
-    def make_train_meta_command(self, args_type: Type[Any]):
-        ResolvedArgsType = NewType("ResolvedArgsType", args_type)  # type: ignore
-        _main_func = self._main_func
+    def make_train_meta_command(self):
+        ResolvedScriptArgsType = NewType("ResolvedScriptArgsType", self.script_args_type)  # type: ignore
+        _main_func = self.main_func
         _logger = self._logger
 
         def train_meta_command(
             *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
             script_args: Annotated[
-                ResolvedArgsType,
-                Parameter(name="*"),  # pyright: ignore[reportInvalidTypeForm]
-            ] = self.args_type(),
+                ResolvedScriptArgsType,
+                Parameter(name="*"),
+            ] = self.script_args_type(),
             hidden_sim_config_dict: Annotated[
                 Optional[Dict[str, Any]], Parameter(parse=False)
             ] = None,
@@ -360,7 +358,7 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
 
     def make(self):
         # setup the default meta func on the base app to parse the Script Args
-        self.app.meta.default(self.make_train_meta_command(self.args_type))
+        self.app.meta.default(self.make_train_meta_command())
         # This takes the config file and adds it to the meta app to allow for the config to be aligned with the script args
         self.app.meta.meta.default(self.make_train_config_handler())
 
@@ -386,7 +384,7 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
             algorithm_type = self.algorithm_table[algorithm]
             algorithm_app.meta.default(
                 self.make_algorithm_command(
-                    algorithm_app, algorithm_type, self.args_type
+                    algorithm_app, algorithm_type
                 )
             )
             self.maybe_make_simulator_commands(algorithm_app)

--- a/Resources/python/schola/scripts/common/command_template.py
+++ b/Resources/python/schola/scripts/common/command_template.py
@@ -227,7 +227,7 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
                 algorithm_app.config = [
                     _ScholaConfig(
                         hidden_sim_config_dict,
-                        use_commands_as_keys=True,
+                        use_commands_as_keys=self.multiple_simulators,
                         allow_unknown=False,
                         source=f"config:environment:simulator",
                     ),
@@ -307,17 +307,16 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
                 ),
             ] = None,
         ):
-            env_key = "environment"
             additional_kwargs: Dict[str, Any] = {}
             config_dict = {}
             if config_file is not None:
                 config_dict = load_yaml_file(config_file, self._logger)
 
-            # if we have a simulator, we need to extract the keys here and then forward them onwards as a hidden argument
-            # this lets us put them at the root level of the app instead of nested in the algorithm command
+            # if we have a simulator, extract ``environment.simulator`` and forward it as a hidden argument
+            # this lets us put it at the root level of the app instead of nested in the algorithm command
             sim_config_dict: Optional[Dict[str, Any]] = None
             if self.has_simulator:
-                sim_config_dict = config_dict.pop(env_key, {}).pop("simulator", {})
+                sim_config_dict = self._create_simulator_config_dict(config_dict)
 
             # we can naively forward the sim_config_dict as we will handle the None checking when we go to actually
             # apply it to the app
@@ -442,6 +441,29 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
     @property
     def has_simulator(self) -> bool:
         return len(self.simulator_table) > 0
+
+    def _create_simulator_config_dict(
+        self, config_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Extract ``environment.simulator`` from *config_dict* and shape it for cyclopts.
+
+        Removes the ``environment.simulator`` block from *config_dict* in place. Config
+        files nest settings under the simulator name (e.g. ``external``). When only one
+        simulator is registered, ``collapse_simulator_command`` inlines that subcommand,
+        so the returned mapping omits the name key.
+        """
+        sim_config_dict = config_dict.pop("environment", {}).pop("simulator", {})
+        if not sim_config_dict or not self.single_simulator:
+            return sim_config_dict
+
+        # single simulator case so we can just return the first and only key from the simulator table
+        simulator_name = next(iter(self.simulator_table))
+        if simulator_name in sim_config_dict:
+            nested = sim_config_dict[simulator_name]
+            return nested if isinstance(nested, dict) else {}
+        # single simulator case where the user inlined the simulator parameters, rather than adding a subcommand key
+        return sim_config_dict
 
     @property
     def has_algorithm(self) -> bool:

--- a/Resources/python/schola/scripts/common/command_template.py
+++ b/Resources/python/schola/scripts/common/command_template.py
@@ -21,16 +21,11 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
-    get_origin,
 )
-
-from webbrowser import GenericBrowser
 
 from cyclopts import App, ArgumentCollection, Group, Parameter
 import cyclopts
 from cyclopts.argument import update_argument_collection
-from pandas.core import generic
 from schola.core.utils.dict_helpers import flatten_dict_no_prefix
 
 from schola.scripts.common.settings import (
@@ -41,7 +36,7 @@ from schola.scripts.common.settings import (
 )
 
 ScriptArgsType = TypeVar("ScriptArgsType")
-AlgorithmArgsType = TypeVar("AlgorithmArgsType")
+
 
 def load_yaml_file(file_path: Path, logger: logging.Logger) -> Dict[str, Any]:
     """
@@ -131,7 +126,6 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
         self.app = app
         self._logger = logger
 
-    
     @property
     def simulator_table(self) -> Dict[str, Type[BaseSimulatorConfig[Any]]]:
         # Ignore the type here as it is difficult to resolve with current typing tooling
@@ -163,12 +157,14 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
 
     @property
     def script_args_type(self) -> Type[ScriptArgsType]:
-        ...
+        raise NotImplementedError(
+            "script_args_type must be implemented in the subclass"
+        )
 
     @property
     def main_func(self) -> Callable[[ScriptArgsType], Any]:
-        ...
-    
+        raise NotImplementedError("main_func must be implemented in the subclass")
+
     def make_simulator_command(self, simulator_type: Type[BaseSimulatorConfig[Any]]):
         SimulatorType = NewType("SimulatorType", simulator_type)  # type: ignore
         _main_func = self.main_func
@@ -187,6 +183,7 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
                 hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
                 self._logger.debug("Arguments: %s", hidden_script_args)
                 return _main_func(hidden_script_args)
+
             return default_simulator_command
         else:
 
@@ -198,11 +195,10 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
                 hidden_script_args.environment_settings.simulator_settings = simulator_args  # type: ignore
                 self._logger.debug("Arguments: %s", hidden_script_args)
                 return _main_func(hidden_script_args)
+
             return non_default_simulator_command
 
-    def make_algorithm_command(
-        self, algorithm_app: App, algorithm_type: Type[Any]
-    ):
+    def make_algorithm_command(self, algorithm_app: App, algorithm_type: Type[Any]):
         AlgorithmType = NewType("AlgorithmType", algorithm_type)  # type: ignore
         _main_func = self.main_func
         _logger = self._logger
@@ -383,9 +379,7 @@ class ScholaCommandTemplate(Generic[ScriptArgsType]):
             )
             algorithm_type = self.algorithm_table[algorithm]
             algorithm_app.meta.default(
-                self.make_algorithm_command(
-                    algorithm_app, algorithm_type
-                )
+                self.make_algorithm_command(algorithm_app, algorithm_type)
             )
             self.maybe_make_simulator_commands(algorithm_app)
 

--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from schola.core.simulators.unreal.project_simulator import UnrealProject
     from schola.core.simulators.external_simulator import ExternalSimulator
 
+
 class ActivationFunctionEnum(str, Enum):
     """
     Activation functions for neural networks.
@@ -79,13 +80,16 @@ def get_activation_function(activation: ActivationFunctionEnum) -> Type["torch.n
     else:
         raise ValueError(f"Unsupported activation function: {activation}")
 
+
 if TYPE_CHECKING:
     from schola.core.simulators.base_simulator import BaseSimulator
 
-T = TypeVar('T', bound="BaseSimulator", covariant=True)
+T = TypeVar("T", bound="BaseSimulator", covariant=True)
 
 
 from abc import ABC, abstractmethod
+
+
 class BaseSimulatorConfig(Generic[T], ABC):
 
     @abstractmethod
@@ -93,6 +97,7 @@ class BaseSimulatorConfig(Generic[T], ABC):
 
     def make_n(self, n: int) -> Sequence[T]:
         return [self.make() for _ in range(n)]
+
 
 @dataclass
 class UnrealExecutableSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
@@ -150,6 +155,7 @@ class UnrealExecutableSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
             self.fps,
             self.disable_script,
         )
+
 
 @dataclass
 class UnrealProjectSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
@@ -214,7 +220,8 @@ class UnrealProjectSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
             disable_script=self.disable_script,
         )
 
-    def make_n(self, n: int) -> list["UnrealExecutable"]:
+    def make_n(self, n: int = 1) -> list["UnrealExecutable"]:
+        assert n >= 1, "Number of simulators must be at least 1"
         primary = self.make()
         return [primary] + primary.spawn(n - 1)
 
@@ -250,7 +257,13 @@ class ExternalSimulatorConfig(BaseSimulatorConfig["ExternalSimulator"]):
 
         return ExternalSimulator(readiness_timeout=self.readiness_timeout)
 
-AllSimulatorConfigs = UnrealExecutableSimulatorConfig | UnrealProjectSimulatorConfig | ExternalSimulatorConfig
+
+AllSimulatorConfigs = (
+    UnrealExecutableSimulatorConfig
+    | UnrealProjectSimulatorConfig
+    | ExternalSimulatorConfig
+)
+
 
 def protocol_port_for_index(base_port: Optional[int], index: int) -> Optional[int]:
     """
@@ -389,12 +402,11 @@ class CheckpointSettings:
         if self.should_persist and not self.checkpoint_dir.exists():
             self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
+
 from typing import Any
 
-SimulatorSettingsT = TypeVar(
-    "SimulatorSettingsT", bound=BaseSimulatorConfig[Any]
-)
-AlgorithmSettingsT = TypeVar("AlgorithmSettingsT", bound=Any)
+SimulatorSettingsT = TypeVar("SimulatorSettingsT", bound=BaseSimulatorConfig[Any])
+
 
 @dataclass
 class EnvironmentSettings(Generic[SimulatorSettingsT]):
@@ -483,5 +495,3 @@ class RllibLauncherExtension:
             A list of additional callbacks to add to the training loop.
         """
         return []
-
-

--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -4,10 +4,12 @@
 Common utility functions and classes for use in Schola scripts.
 """
 
+from collections.abc import Sequence
 from enum import Enum
 from typing import (
     Annotated,
     Dict,
+    Generic,
     Literal,
     Optional,
     Tuple,
@@ -82,15 +84,16 @@ if TYPE_CHECKING:
 
 T = TypeVar('T', bound="BaseSimulator", covariant=True)
 
+
 from abc import ABC, abstractmethod
 class BaseSimulatorConfig(Generic[T], ABC):
 
     @abstractmethod
     def make(self) -> T: ...
 
-    def make_n(self, n: int) -> list[T]:
+    def make_n(self, n: int) -> Sequence[T]:
         return [self.make() for _ in range(n)]
-        
+
 @dataclass
 class UnrealExecutableSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
     """
@@ -149,7 +152,7 @@ class UnrealExecutableSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
         )
 
 @dataclass
-class UnrealProjectSimulatorConfig(BaseSimulatorConfig["UnrealProject"]):
+class UnrealProjectSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
     """
     Arguments for the Unreal Engine project simulator in Schola.
     """
@@ -247,6 +250,7 @@ class ExternalSimulatorConfig(BaseSimulatorConfig["ExternalSimulator"]):
 
         return ExternalSimulator(readiness_timeout=self.readiness_timeout)
 
+AllSimulatorConfigs = UnrealExecutableSimulatorConfig | UnrealProjectSimulatorConfig | ExternalSimulatorConfig
 
 def protocol_port_for_index(base_port: Optional[int], index: int) -> Optional[int]:
     """
@@ -390,7 +394,7 @@ from typing import Any
 SimulatorSettingsT = TypeVar(
     "SimulatorSettingsT", bound=BaseSimulatorConfig[Any]
 )
-
+AlgorithmSettingsT = TypeVar("AlgorithmSettingsT", bound=Any)
 
 @dataclass
 class EnvironmentSettings(Generic[SimulatorSettingsT]):
@@ -479,3 +483,5 @@ class RllibLauncherExtension:
             A list of additional callbacks to add to the training loop.
         """
         return []
+
+

--- a/Resources/python/schola/scripts/common/settings.py
+++ b/Resources/python/schola/scripts/common/settings.py
@@ -24,6 +24,12 @@ from rich.console import Console
 
 console = Console()
 
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from schola.core.simulators.unreal.executable_simulator import UnrealExecutable
+    from schola.core.simulators.unreal.project_simulator import UnrealProject
+    from schola.core.simulators.external_simulator import ExternalSimulator
 
 class ActivationFunctionEnum(str, Enum):
     """
@@ -71,9 +77,22 @@ def get_activation_function(activation: ActivationFunctionEnum) -> Type["torch.n
     else:
         raise ValueError(f"Unsupported activation function: {activation}")
 
+if TYPE_CHECKING:
+    from schola.core.simulators.base_simulator import BaseSimulator
 
+T = TypeVar('T', bound="BaseSimulator", covariant=True)
+
+from abc import ABC, abstractmethod
+class BaseSimulatorConfig(Generic[T], ABC):
+
+    @abstractmethod
+    def make(self) -> T: ...
+
+    def make_n(self, n: int) -> list[T]:
+        return [self.make() for _ in range(n)]
+        
 @dataclass
-class UnrealExecutableSimulatorConfig:
+class UnrealExecutableSimulatorConfig(BaseSimulatorConfig["UnrealExecutable"]):
     """
     Arguments for the Unreal Engine executable simulator in Schola.
 
@@ -109,7 +128,7 @@ class UnrealExecutableSimulatorConfig:
     ] = 1
     "Number of parallel simulator processes. Headless mode is recommended when N > 1. With a fixed port P, instances use P, P+1, ... P+N-1."
 
-    def make(self):
+    def make(self) -> "UnrealExecutable":
         """
         Create an UnrealExecutable simulator instance with the specified settings.
 
@@ -129,9 +148,8 @@ class UnrealExecutableSimulatorConfig:
             self.disable_script,
         )
 
-
 @dataclass
-class UnrealProjectSimulatorConfig:
+class UnrealProjectSimulatorConfig(BaseSimulatorConfig["UnrealProject"]):
     """
     Arguments for the Unreal Engine project simulator in Schola.
     """
@@ -170,7 +188,7 @@ class UnrealProjectSimulatorConfig:
     ] = 1
     "Number of parallel simulator processes. One project build is used; headless recommended when N > 1. With a fixed port P, instances use P, P+1, ... P+N-1."
 
-    def make(self):
+    def make(self) -> "UnrealProject":
         """
         Create a UnrealProject simulator instance with the specified settings.
 
@@ -193,9 +211,13 @@ class UnrealProjectSimulatorConfig:
             disable_script=self.disable_script,
         )
 
+    def make_n(self, n: int) -> list["UnrealExecutable"]:
+        primary = self.make()
+        return [primary] + primary.spawn(n - 1)
+
 
 @dataclass
-class ExternalSimulatorConfig:
+class ExternalSimulatorConfig(BaseSimulatorConfig["ExternalSimulator"]):
     """
     Arguments for an externally managed process.
 
@@ -212,7 +234,7 @@ class ExternalSimulatorConfig:
     readiness_timeout: Optional[int] = None
     "Seconds to wait for the external process to become reachable (reserved for future use)."
 
-    def make(self):
+    def make(self) -> "ExternalSimulator":
         """
         Create an ExternalSimulator instance.
 
@@ -363,21 +385,23 @@ class CheckpointSettings:
         if self.should_persist and not self.checkpoint_dir.exists():
             self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
+from typing import Any
+
+SimulatorSettingsT = TypeVar(
+    "SimulatorSettingsT", bound=BaseSimulatorConfig[Any]
+)
+
 
 @dataclass
-class EnvironmentSettings:
+class EnvironmentSettings(Generic[SimulatorSettingsT]):
     """
     Settings for the environment in Schola.
     """
 
     simulator_settings: Annotated[
-        Union[
-            UnrealExecutableSimulatorConfig,
-            UnrealProjectSimulatorConfig,
-            ExternalSimulatorConfig,
-        ],
+        SimulatorSettingsT,
         IgnoreParameter,
-    ] = field(default_factory=ExternalSimulatorConfig)
+    ]
     "Settings for the simulator to use during training"
 
     protocol_settings: Annotated[

--- a/Resources/python/schola/scripts/minari/collect.py
+++ b/Resources/python/schola/scripts/minari/collect.py
@@ -136,10 +136,11 @@ class CollectMinariCommand(ScholaCommandTemplate[MinariScriptSettings]):
     @property
     def script_args_type(self) -> Type[MinariScriptSettings]:
         return MinariScriptSettings
-    
+
     @property
     def main_func(self) -> Callable[[MinariScriptSettings], Any]:
         return main
+
 
 collect_app = CollectMinariCommand(_collect_app, logger).make()
 

--- a/Resources/python/schola/scripts/minari/collect.py
+++ b/Resources/python/schola/scripts/minari/collect.py
@@ -5,7 +5,7 @@ Script to collect imitation learning datasets using Minari and Schola.
 """
 
 import logging
-from typing import Literal
+from typing import Any, Callable, Literal, Type
 from typing_extensions import Annotated
 
 from schola.scripts.common.command_template import ScholaCommandTemplate
@@ -129,13 +129,17 @@ _collect_app = App(
 
 class CollectMinariCommand(ScholaCommandTemplate[MinariScriptSettings]):
 
-    def __init__(self, app: App, logger: logging.Logger):
-        super().__init__(app, MinariScriptSettings, main, logger)
-
     @property
     def algorithm_table(self):
         return {}
 
+    @property
+    def script_args_type(self) -> Type[MinariScriptSettings]:
+        return MinariScriptSettings
+    
+    @property
+    def main_func(self) -> Callable[[MinariScriptSettings], Any]:
+        return main
 
 collect_app = CollectMinariCommand(_collect_app, logger).make()
 

--- a/Resources/python/schola/scripts/minari/settings.py
+++ b/Resources/python/schola/scripts/minari/settings.py
@@ -12,7 +12,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from cyclopts import Parameter, validators
 from cyclopts.types import URL, Email
-from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
+from schola.scripts.common.settings import (
+    AllSimulatorConfigs,
+    EnvironmentSettings,
+    ExternalSimulatorConfig,
+    IgnoreParameter,
+)
 
 
 @dataclass
@@ -78,7 +83,7 @@ class MinariEnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
     """
     Dataclass for configuring the environment settings for Minari data collection.
     """
-    
+
     simulator_settings: Annotated[
         AllSimulatorConfigs,
         IgnoreParameter,
@@ -105,6 +110,7 @@ class MinariScriptSettings:
         MinariEnvironmentSettings, Parameter(group="Environment Arguments", name="*")
     ] = field(default_factory=MinariEnvironmentSettings)
     "Settings for configuring the environment."
+
 
 # Deprecated: use *Settings names. Kept for external isinstance / imports.
 MinariScriptArgs = MinariScriptSettings

--- a/Resources/python/schola/scripts/minari/settings.py
+++ b/Resources/python/schola/scripts/minari/settings.py
@@ -7,12 +7,12 @@ Cyclopts dataclasses for Minari dataset collection with Schola.
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Optional
+from typing import TYPE_CHECKING, Annotated, Optional
 from dataclasses import dataclass, field
 from pathlib import Path
 from cyclopts import Parameter, validators
 from cyclopts.types import URL, Email
-from schola.scripts.common.settings import EnvironmentSettings
+from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
 
 
 @dataclass
@@ -74,6 +74,18 @@ class MinariLoggingSettings:
 
 
 @dataclass
+class MinariEnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
+    """
+    Dataclass for configuring the environment settings for Minari data collection.
+    """
+    
+    simulator_settings: Annotated[
+        AllSimulatorConfigs,
+        IgnoreParameter,
+    ] = field(default_factory=ExternalSimulatorConfig)
+
+
+@dataclass
 class MinariScriptSettings:
     """
     Top level dataclass for configuring the script arguments used in the Minari data collection launcher.
@@ -90,10 +102,9 @@ class MinariScriptSettings:
     "Settings for configuring logging during data collection."
 
     environment_settings: Annotated[
-        EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
-    ] = field(default_factory=EnvironmentSettings)
+        MinariEnvironmentSettings, Parameter(group="Environment Arguments", name="*")
+    ] = field(default_factory=MinariEnvironmentSettings)
     "Settings for configuring the environment."
-
 
 # Deprecated: use *Settings names. Kept for external isinstance / imports.
 MinariScriptArgs = MinariScriptSettings

--- a/Resources/python/schola/scripts/rllib/eval/eval.py
+++ b/Resources/python/schola/scripts/rllib/eval/eval.py
@@ -273,9 +273,16 @@ class RllibEvalCommand(ScholaCommandTemplate[RllibEvalScriptSettings]):
     @property
     def algorithm_table(self) -> Dict[str, Type[Any]]:
         return {}
+    
+    @property
+    def script_args_type(self) -> Type[RllibEvalScriptSettings]:
+        return RllibEvalScriptSettings
+    
+    @property
+    def main_func(self) -> Callable[[RllibEvalScriptSettings], Any]:
+        return main
 
-
-app = RllibEvalCommand(app, RllibEvalScriptSettings, main, logger).make()
+app = RllibEvalCommand(app, logger).make()
 
 if __name__ == "__main__":
     app.meta()

--- a/Resources/python/schola/scripts/rllib/eval/eval.py
+++ b/Resources/python/schola/scripts/rllib/eval/eval.py
@@ -273,14 +273,15 @@ class RllibEvalCommand(ScholaCommandTemplate[RllibEvalScriptSettings]):
     @property
     def algorithm_table(self) -> Dict[str, Type[Any]]:
         return {}
-    
+
     @property
     def script_args_type(self) -> Type[RllibEvalScriptSettings]:
         return RllibEvalScriptSettings
-    
+
     @property
     def main_func(self) -> Callable[[RllibEvalScriptSettings], Any]:
         return main
+
 
 app = RllibEvalCommand(app, logger).make()
 

--- a/Resources/python/schola/scripts/rllib/eval/settings.py
+++ b/Resources/python/schola/scripts/rllib/eval/settings.py
@@ -9,9 +9,17 @@ from dataclasses import dataclass, field
 
 from cyclopts import Parameter, validators
 
-from schola.scripts.common.settings import EnvironmentSettings, AllSimulatorConfigs, ExternalSimulatorConfig
+from schola.scripts.common.settings import (
+    EnvironmentSettings,
+    AllSimulatorConfigs,
+    ExternalSimulatorConfig,
+)
 
-from schola.scripts.rllib.settings import LoggingSettings, ResourceSettings, RllibEnvironmentSettings
+from schola.scripts.rllib.settings import (
+    LoggingSettings,
+    ResourceSettings,
+    RllibEnvironmentSettings,
+)
 
 
 @dataclass

--- a/Resources/python/schola/scripts/rllib/eval/settings.py
+++ b/Resources/python/schola/scripts/rllib/eval/settings.py
@@ -3,15 +3,15 @@
 Settings dataclasses for the RLlib evaluation command.
 """
 
-from typing import Annotated, Dict, Optional
+from typing import TYPE_CHECKING, Annotated, Dict, Optional
 from pathlib import Path
 from dataclasses import dataclass, field
 
 from cyclopts import Parameter, validators
 
-from schola.scripts.common.settings import EnvironmentSettings
+from schola.scripts.common.settings import EnvironmentSettings, AllSimulatorConfigs, ExternalSimulatorConfig
 
-from schola.scripts.rllib.settings import LoggingSettings, ResourceSettings
+from schola.scripts.rllib.settings import LoggingSettings, ResourceSettings, RllibEnvironmentSettings
 
 
 @dataclass
@@ -52,6 +52,6 @@ class RllibEvalScriptSettings:
     "Logging verbosity for Schola and RLlib."
 
     environment_settings: Annotated[
-        EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
-    ] = field(default_factory=EnvironmentSettings)
+        RllibEnvironmentSettings, Parameter(group="Environment Arguments", name="*")
+    ] = field(default_factory=RllibEnvironmentSettings)
     "Settings for the environment to use during evaluation"

--- a/Resources/python/schola/scripts/rllib/settings.py
+++ b/Resources/python/schola/scripts/rllib/settings.py
@@ -8,7 +8,12 @@ from dataclasses import dataclass, field
 
 from cyclopts import Parameter, validators
 
-from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
+from schola.scripts.common.settings import (
+    AllSimulatorConfigs,
+    EnvironmentSettings,
+    ExternalSimulatorConfig,
+    IgnoreParameter,
+)
 
 
 class RllibAlgorithmSpecificSettings:
@@ -243,7 +248,7 @@ class RllibEnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
     """
     Dataclass for configuring the environment settings for RLlib training.
     """
-    
+
     simulator_settings: Annotated[
         AllSimulatorConfigs,
         IgnoreParameter,

--- a/Resources/python/schola/scripts/rllib/settings.py
+++ b/Resources/python/schola/scripts/rllib/settings.py
@@ -4,9 +4,11 @@ Shared settings dataclasses for RLlib scripts (algorithms, resources, logging).
 """
 
 from typing import Annotated, Any, Dict, Type
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from cyclopts import Parameter, validators
+
+from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
 
 
 class RllibAlgorithmSpecificSettings:
@@ -234,3 +236,15 @@ class LoggingSettings:
             2: "INFO",
             3: "DEBUG",
         }[self.rllib_verbosity]
+
+
+@dataclass
+class RllibEnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
+    """
+    Dataclass for configuring the environment settings for RLlib training.
+    """
+    
+    simulator_settings: Annotated[
+        AllSimulatorConfigs,
+        IgnoreParameter,
+    ] = field(default_factory=ExternalSimulatorConfig)

--- a/Resources/python/schola/scripts/rllib/train/settings.py
+++ b/Resources/python/schola/scripts/rllib/train/settings.py
@@ -12,7 +12,6 @@ from cyclopts import Parameter, validators
 from schola.scripts.common.settings import (
     ActivationFunctionEnum,
     CheckpointSettings,
-    EnvironmentSettings,
 )
 
 from schola.scripts.rllib.settings import (
@@ -21,6 +20,7 @@ from schola.scripts.rllib.settings import (
     LoggingSettings,
     PPOSettings,
     ResourceSettings,
+    RllibEnvironmentSettings,
     SACSettings,
 )
 
@@ -182,8 +182,9 @@ class RllibScriptSettings:
     "Settings for checkpoints"
 
     environment_settings: Annotated[
-        EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
-    ] = field(default_factory=EnvironmentSettings)
+        RllibEnvironmentSettings,
+        Parameter(group="Environment Arguments", name="*"),
+    ] = field(default_factory=RllibEnvironmentSettings)
     "Settings for the environment to use during training"
 
 
@@ -195,4 +196,4 @@ LoggingArgs = LoggingSettings
 ResumeArgs = ResumeSettings
 NetworkArchitectureArgs = NetworkArchitectureSettings
 CheckpointArgs = CheckpointSettings
-EnvironmentArgs = EnvironmentSettings
+EnvironmentArgs = RllibEnvironmentSettings

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -7,7 +7,7 @@ Script to train an rllib model using Schola.
 import logging
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from schola.scripts.common.settings import (
     get_activation_function,
@@ -406,8 +406,16 @@ class RllibTrainCommand(ScholaCommandTemplate[RllibScriptSettings]):
             "appo": "Train a model using Asynchronous Proximal Policy Optimization(APPO) with rllib.",
         }
 
+    @property
+    def script_args_type(self) -> Type[RllibScriptSettings]:
+        return RllibScriptSettings
+    
+    @property
+    def main_func(self) -> Callable[[RllibScriptSettings], Any]:
+        return main
 
-app = RllibTrainCommand(app, RllibScriptSettings, main, logger).make()
+
+app = RllibTrainCommand(app, logger).make()
 
 if __name__ == "__main__":
     app.meta()

--- a/Resources/python/schola/scripts/rllib/train/train.py
+++ b/Resources/python/schola/scripts/rllib/train/train.py
@@ -409,7 +409,7 @@ class RllibTrainCommand(ScholaCommandTemplate[RllibScriptSettings]):
     @property
     def script_args_type(self) -> Type[RllibScriptSettings]:
         return RllibScriptSettings
-    
+
     @property
     def main_func(self) -> Callable[[RllibScriptSettings], Any]:
         return main

--- a/Resources/python/schola/scripts/sb3/eval/eval.py
+++ b/Resources/python/schola/scripts/sb3/eval/eval.py
@@ -6,7 +6,7 @@ Evaluate a trained Stable-Baselines3 policy against a Schola-backed environment.
 
 import logging
 import signal
-from typing import List, Tuple, cast, Any
+from typing import Callable, List, Tuple, Type, cast, Any
 
 from cyclopts import App
 from schola.scripts.common.command_template import ScholaCommandTemplate
@@ -155,6 +155,13 @@ class MetaEvalSB3Command(ScholaCommandTemplate[Sb3EvalScriptSettings]):
             "sac": "Evaluate a model trained using Soft Actor-Critic(SAC) with StableBaselines3.",
             "ppo": "Evaluate a model trained using Proximal Policy Optimization(PPO) with StableBaselines3.",
         }
+    @property
+    def script_args_type(self) -> Type[Sb3EvalScriptSettings]:
+        return Sb3EvalScriptSettings
+    
+    @property
+    def main_func(self) -> Callable[[Sb3EvalScriptSettings], Any]:
+        return main
 
 
-app = MetaEvalSB3Command(app, Sb3EvalScriptSettings, main, logger).make()
+app = MetaEvalSB3Command(app, logger).make()

--- a/Resources/python/schola/scripts/sb3/eval/eval.py
+++ b/Resources/python/schola/scripts/sb3/eval/eval.py
@@ -64,8 +64,7 @@ def main(args: Sb3EvalScriptSettings) -> Tuple[float, float]:
                     verbosity=args.logging_settings.schola_verbosity,
                 )
             else:
-                primary = cast(UnrealExecutable, sim_args.make())
-                simulators = [primary] + primary.spawn_executables(n_sim - 1)
+                simulators = sim_args.make_n(n_sim)
                 async_protocols = protocol_args.make_n_async(n_sim)
                 env = AsyncVecEnv(
                     simulators,
@@ -155,10 +154,11 @@ class MetaEvalSB3Command(ScholaCommandTemplate[Sb3EvalScriptSettings]):
             "sac": "Evaluate a model trained using Soft Actor-Critic(SAC) with StableBaselines3.",
             "ppo": "Evaluate a model trained using Proximal Policy Optimization(PPO) with StableBaselines3.",
         }
+
     @property
     def script_args_type(self) -> Type[Sb3EvalScriptSettings]:
         return Sb3EvalScriptSettings
-    
+
     @property
     def main_func(self) -> Callable[[Sb3EvalScriptSettings], Any]:
         return main

--- a/Resources/python/schola/scripts/sb3/eval/settings.py
+++ b/Resources/python/schola/scripts/sb3/eval/settings.py
@@ -5,13 +5,12 @@ Cyclopts dataclasses for evaluating a saved SB3 policy with Schola.
 """
 
 from dataclasses import dataclass, field
-from typing import Annotated, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Optional, Union
 from pathlib import Path
 from cyclopts import Parameter, validators
-from schola.scripts.common.settings import EnvironmentSettings
-from schola.scripts.sb3.settings import Sb3BaseLoggingSettings
+from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
+from schola.scripts.sb3.settings import Sb3BaseLoggingSettings, Sb3EnvironmentSettings
 from schola.scripts.sb3.settings import BasePPOSettings, BaseSACSettings
-
 
 @dataclass
 class Sb3EvalScriptSettings:
@@ -53,11 +52,11 @@ class Sb3EvalScriptSettings:
     "Logging verbosity for Schola and SB3 components."
 
     environment_settings: Annotated[
-        EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
-    ] = field(default_factory=EnvironmentSettings)
+        Sb3EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
+    ] = field(default_factory=Sb3EnvironmentSettings)
     "How to launch or attach to the Unreal simulator and gRPC protocol for the environment."
 
     algorithm_settings: Annotated[
-        Union[BasePPOSettings, BaseSACSettings], Parameter(show=False, parse=False)
+        Union[BasePPOSettings, BaseSACSettings], IgnoreParameter
     ] = field(default_factory=BasePPOSettings)
     "The algorithm used to train the checkpoint that is being evaluated."

--- a/Resources/python/schola/scripts/sb3/eval/settings.py
+++ b/Resources/python/schola/scripts/sb3/eval/settings.py
@@ -8,9 +8,15 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Annotated, Optional, Union
 from pathlib import Path
 from cyclopts import Parameter, validators
-from schola.scripts.common.settings import AllSimulatorConfigs, EnvironmentSettings, ExternalSimulatorConfig, IgnoreParameter
+from schola.scripts.common.settings import (
+    AllSimulatorConfigs,
+    EnvironmentSettings,
+    ExternalSimulatorConfig,
+    IgnoreParameter,
+)
 from schola.scripts.sb3.settings import Sb3BaseLoggingSettings, Sb3EnvironmentSettings
 from schola.scripts.sb3.settings import BasePPOSettings, BaseSACSettings
+
 
 @dataclass
 class Sb3EvalScriptSettings:

--- a/Resources/python/schola/scripts/sb3/settings.py
+++ b/Resources/python/schola/scripts/sb3/settings.py
@@ -13,6 +13,9 @@ from schola.scripts.common.settings import (
     EnvironmentSettings,
     CheckpointSettings,
     Sb3LauncherExtension,
+    AllSimulatorConfigs,
+    ExternalSimulatorConfig,
+    IgnoreParameter,
 )
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -72,3 +75,14 @@ class BasePPOSettings:
     @property
     def name(self) -> str:
         return "PPO"
+
+@dataclass
+class Sb3EnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
+    """
+    Dataclass for configuring the environment settings for SB3 Scripts.
+    """
+    
+    simulator_settings: Annotated[
+        AllSimulatorConfigs,
+        IgnoreParameter,
+    ] = field(default_factory=ExternalSimulatorConfig)

--- a/Resources/python/schola/scripts/sb3/settings.py
+++ b/Resources/python/schola/scripts/sb3/settings.py
@@ -76,12 +76,13 @@ class BasePPOSettings:
     def name(self) -> str:
         return "PPO"
 
+
 @dataclass
 class Sb3EnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
     """
     Dataclass for configuring the environment settings for SB3 Scripts.
     """
-    
+
     simulator_settings: Annotated[
         AllSimulatorConfigs,
         IgnoreParameter,

--- a/Resources/python/schola/scripts/sb3/train/settings.py
+++ b/Resources/python/schola/scripts/sb3/train/settings.py
@@ -10,7 +10,9 @@ from typing import Annotated, List, Optional, Type, Union, Any, Dict
 
 from schola.scripts.common.settings import (
     ActivationFunctionEnum,
+    AllSimulatorConfigs,
     EnvironmentSettings,
+    ExternalSimulatorConfig,
     CheckpointSettings,
     Sb3LauncherExtension,
 )
@@ -24,6 +26,7 @@ from schola.scripts.sb3.settings import (
     BaseSACSettings,
     BasePPOSettings,
     Sb3BaseLoggingSettings,
+    Sb3EnvironmentSettings,
 )
 
 
@@ -337,9 +340,6 @@ class Sb3NetworkArchitectureSettings:
             )
 
 
-IgnoreParameter = Parameter(show=False, parse=False)
-
-
 @dataclass
 class Sb3TrainingSettings:
     """
@@ -404,6 +404,6 @@ class Sb3TrainScriptSettings:
         )
 
     environment_settings: Annotated[
-        EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
-    ] = field(default_factory=EnvironmentSettings)
+        Sb3EnvironmentSettings, Parameter(group="Environment Arguments", name="*")
+    ] = field(default_factory=Sb3EnvironmentSettings)
     "Settings for the environment to use during training"

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -163,8 +163,7 @@ def main(args: Sb3TrainScriptSettings) -> Optional[Tuple[float, float]]:
                     UnrealExecutable,
                 )
 
-                primary = cast(UnrealExecutable, sim_args.make())
-                simulators = [primary] + primary.spawn_executables(n_sim - 1)
+                simulators = sim_args.make_n(n_sim)
                 async_protocols = protocol_args.make_n_async(n_sim)
                 env = AsyncVecEnv(
                     simulators,
@@ -416,9 +415,10 @@ class MetaTrainSB3Command(ScholaCommandTemplate[Sb3TrainScriptSettings]):
     @property
     def script_args_type(self) -> Type[Sb3TrainScriptSettings]:
         return Sb3TrainScriptSettings
-    
+
     @property
     def main_func(self) -> Callable[[Sb3TrainScriptSettings], Any]:
         return main
+
 
 app = MetaTrainSB3Command(app, logger).make()

--- a/Resources/python/schola/scripts/sb3/train/train.py
+++ b/Resources/python/schola/scripts/sb3/train/train.py
@@ -10,9 +10,11 @@ import logging
 import signal
 from typing import (
     Any,
+    Callable,
     Dict,
     Optional,
     Tuple,
+    Type,
     cast,
 )
 
@@ -411,5 +413,12 @@ class MetaTrainSB3Command(ScholaCommandTemplate[Sb3TrainScriptSettings]):
             "ppo": "Train a model using Proximal Policy Optimization(PPO) with StableBaselines3.",
         }
 
+    @property
+    def script_args_type(self) -> Type[Sb3TrainScriptSettings]:
+        return Sb3TrainScriptSettings
+    
+    @property
+    def main_func(self) -> Callable[[Sb3TrainScriptSettings], Any]:
+        return main
 
-app = MetaTrainSB3Command(app, Sb3TrainScriptSettings, main, logger).make()
+app = MetaTrainSB3Command(app, logger).make()

--- a/Test/minari/scripts/test_minari_cli.py
+++ b/Test/minari/scripts/test_minari_cli.py
@@ -38,7 +38,15 @@ def mock_app(mock_main):
         def algorithm_table(self):
             return {}
 
-    app = MetaCollectMinariCommand(app, MinariScriptSettings, mock_main, logger).make()
+        @property
+        def script_args_type(self):
+            return MinariScriptSettings
+        
+        @property
+        def main_func(self):
+            return mock_main
+
+    app = MetaCollectMinariCommand(app, logger).make()
     return app.meta
 
 

--- a/Test/rllib/scripts/test_env_config.py
+++ b/Test/rllib/scripts/test_env_config.py
@@ -3,12 +3,9 @@
 
 from pathlib import Path
 
+from schola.scripts.common.settings import GrpcProtocolConfig, UnrealExecutableSimulatorConfig
+from schola.scripts.rllib.settings import RllibEnvironmentSettings
 from schola.scripts.rllib.utils import build_env_config
-from schola.scripts.common.settings import (
-    EnvironmentSettings,
-    GrpcProtocolConfig,
-    UnrealExecutableSimulatorConfig,
-)
 
 # ---- build_env_config tests ------------------------------------------------
 
@@ -19,7 +16,7 @@ def test_build_env_config_defaults_to_external_simulator():
     from schola.core.protocols.protobuf.grpc_protocol import GrpcProtocol
     from schola.core.simulators.external_simulator import ExternalSimulator
 
-    env = EnvironmentSettings(
+    env = RllibEnvironmentSettings(
         protocol_settings=GrpcProtocolConfig(url="localhost", port=1),
         env_options={"k": "v"},
     )
@@ -40,7 +37,7 @@ def test_build_env_config_uses_executable_simulator(tmp_path: Path):
 
     exe = tmp_path / "game.exe"
     exe.write_text("")
-    env = EnvironmentSettings(
+    env = RllibEnvironmentSettings(
         simulator_settings=UnrealExecutableSimulatorConfig(executable_path=exe),
     )
 
@@ -55,7 +52,7 @@ def test_build_env_config_reuses_passed_simulator(mocker):
     """A caller-supplied simulator is serialized directly without constructing a
     second one. Guards the train double-build regression: training builds its
     simulator once for space discovery and hands it to ``build_env_config``."""
-    env = EnvironmentSettings(
+    env = RllibEnvironmentSettings(
         protocol_settings=GrpcProtocolConfig(url="localhost", port=1),
     )
     prebuilt = env.simulator_settings.make()

--- a/Test/rllib/scripts/test_eval_cli.py
+++ b/Test/rllib/scripts/test_eval_cli.py
@@ -15,7 +15,7 @@ from schola.scripts.rllib.eval.eval import (
 )
 from schola.rllib.checkpoint import rl_module_dir_from_algorithm_checkpoint
 from schola.scripts.rllib.eval.settings import RllibEvalScriptSettings
-from schola.scripts.rllib.settings import ResourceSettings
+from schola.scripts.rllib.settings import RllibEnvironmentSettings, ResourceSettings
 
 
 @pytest.fixture
@@ -27,7 +27,13 @@ def mock_main(mocker):
 def mock_eval_app(mock_main):
     base = App(name="eval", help="Evaluate a trained RLlib policy from a checkpoint")
     logger = logging.getLogger(__name__)
-    return RllibEvalCommand(base, RllibEvalScriptSettings, mock_main, logger).make()
+
+    class TestRllibEvalCommand(RllibEvalCommand):
+        @property
+        def main_func(self):
+            return mock_main
+
+    return TestRllibEvalCommand(base, logger).make()
 
 
 @pytest.fixture
@@ -35,7 +41,7 @@ def rllib_eval_meta_app():
     """Real ``schola rllib eval`` Cyclopts meta-app (invokes ``eval_main``)."""
     base = App(name="eval", help="Evaluate a trained RLlib policy from a checkpoint")
     logger = logging.getLogger(__name__)
-    return RllibEvalCommand(base, RllibEvalScriptSettings, eval_main, logger).make()
+    return RllibEvalCommand(base, logger).make()
 
 
 @pytest.fixture
@@ -64,11 +70,7 @@ def dummy_rllib_checkpoint_dir(
         ScholaPolicyMappingCheckpoint,
     )
     from schola.scripts.rllib.utils import build_env_config, discover_env_metadata
-    from schola.scripts.common.settings import (
-        EnvironmentSettings,
-        GrpcProtocolConfig,
-        PortOffsetMode,
-    )
+    from schola.scripts.common.settings import GrpcProtocolConfig, PortOffsetMode
 
     train_port = make_vec_env_server([make_env("CartPole-v1", 0)])
 
@@ -76,7 +78,7 @@ def dummy_rllib_checkpoint_dir(
     # use, so the checkpoint matches a real run. ``fixed`` keeps the single
     # local runner on the training server port.
     env_config = build_env_config(
-        EnvironmentSettings(
+        RllibEnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(
                 url="localhost", port=train_port, port_offset_mode=PortOffsetMode.FIXED
             ),
@@ -127,7 +129,7 @@ def dummy_rllib_checkpoint_dir(
         algo.train()
         ckpt = tmp_path / "rllib_eval_ckpt"
         algo.save(str(ckpt))
-        train_env_settings = EnvironmentSettings(
+        train_env_settings = RllibEnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(
                 url="localhost", port=train_port, port_offset_mode=PortOffsetMode.FIXED
             ),
@@ -159,13 +161,13 @@ def test_rllib_eval_main_on_real_checkpoint(dummy_rllib_checkpoint_dir):
     """``eval_main`` restores the checkpoint, rebuilds the env from the CLI
     protocol args (pointed at the dedicated eval server) and evaluates for real."""
     pytest.importorskip("ray")
-    from schola.scripts.common.settings import EnvironmentSettings, GrpcProtocolConfig
+    from schola.scripts.common.settings import GrpcProtocolConfig
 
     ckpt, eval_port = dummy_rllib_checkpoint_dir
     args = RllibEvalScriptSettings(
         checkpoint=ckpt,
         n_eval_episodes=2,
-        environment_settings=EnvironmentSettings(
+        environment_settings=RllibEnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(url="localhost", port=eval_port),
         ),
         resource_settings=ResourceSettings(using_cluster=True),
@@ -196,6 +198,7 @@ def test_rllib_eval_cli_on_real_checkpoint(
             "--using-cluster",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     assert isinstance(results, dict)
     env_metrics = results.get("env_runners") or results.get("evaluation")
@@ -210,7 +213,11 @@ def test_eval_cli_forwards_checkpoint_and_defaults(
 ):
     ckpt = tmp_path / "checkpoint_000001"
     ckpt.mkdir()
-    mock_eval_app.meta(["--checkpoint", str(ckpt)], result_action="return_value")
+    mock_eval_app.meta(
+        ["--checkpoint", str(ckpt)],
+        result_action="return_value",
+        exit_on_error=False,
+    )
     mock_main.assert_called_once()
     args = mock_main.call_args[0][0]
     assert isinstance(args, RllibEvalScriptSettings)
@@ -224,6 +231,7 @@ def test_eval_cli_custom_episodes(mock_eval_app, mock_main, tmp_path: Path):
     mock_eval_app.meta(
         ["--checkpoint", str(ckpt), "--n-eval-episodes", "5"],
         result_action="return_value",
+        exit_on_error=False,
     )
     args = mock_main.call_args[0][0]
     assert args.n_eval_episodes == 5
@@ -235,7 +243,11 @@ def test_eval_cli_env_options_default_is_empty_dict(
     """Without ``--env-options.k=v`` the field defaults to an empty dict."""
     ckpt = tmp_path / "c"
     ckpt.mkdir()
-    mock_eval_app.meta(["--checkpoint", str(ckpt)], result_action="return_value")
+    mock_eval_app.meta(
+        ["--checkpoint", str(ckpt)],
+        result_action="return_value",
+        exit_on_error=False,
+    )
     args = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {}
 
@@ -252,6 +264,7 @@ def test_eval_cli_env_options_dotted_syntax(mock_eval_app, mock_main, tmp_path: 
             "--env-options.curriculum=easy",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     args = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {"level": "1", "curriculum": "easy"}
@@ -265,11 +278,7 @@ def make_eval_args(tmp_path: Path):
     """Factory for ``RllibEvalScriptSettings`` over an existing (empty) checkpoint
     dir. ``num_simulators`` and ``env_options`` are the per-call knobs used by the
     settings-derived helper tests."""
-    from schola.scripts.common.settings import (
-        EnvironmentSettings,
-        ExternalSimulatorConfig,
-        GrpcProtocolConfig,
-    )
+    from schola.scripts.common.settings import ExternalSimulatorConfig, GrpcProtocolConfig
 
     def _make(
         *, num_simulators: int = 1, env_options: dict | None = None
@@ -279,7 +288,7 @@ def make_eval_args(tmp_path: Path):
         return RllibEvalScriptSettings(
             checkpoint=ckpt,
             n_eval_episodes=2,
-            environment_settings=EnvironmentSettings(
+            environment_settings=RllibEnvironmentSettings(
                 simulator_settings=ExternalSimulatorConfig(
                     num_simulators=num_simulators
                 ),

--- a/Test/rllib/scripts/test_train_cli.py
+++ b/Test/rllib/scripts/test_train_cli.py
@@ -59,8 +59,13 @@ def mock_app(mock_main):
     """Build a fresh app with mocked main (no global injection)."""
     app = App(name="train", help="Train a Model using ray")
     logger = logging.getLogger(__name__)
-    app = RllibTrainCommand(app, RllibScriptSettings, mock_main, logger).make()
-    return app
+
+    class MockRllibTrainCommand(RllibTrainCommand):
+        @property
+        def main_func(self):
+            return mock_main
+
+    return MockRllibTrainCommand(app, logger).make()
 
 
 def test_agent_type_policy_mapping_fn():
@@ -176,7 +181,7 @@ def test_make_stop_criterion_reset_no_checkpoint_uses_timesteps():
 
 def test_ppo_default_arguments(mock_app, mock_main):
     """Test PPO command with default arguments."""
-    mock_app.meta(["ppo"], result_action="return_value")
+    mock_app.meta(["ppo"], result_action="return_value", exit_on_error=False)
 
     # Verify main was called once
     mock_main.assert_called_once()
@@ -228,6 +233,7 @@ def test_ppo_custom_training_parameters(mock_app, mock_main):
             "10",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -244,7 +250,7 @@ def test_ppo_custom_training_parameters(mock_app, mock_main):
 
 def test_ppo_seed_argument(mock_app, mock_main):
     """Test PPO command accepts --seed for reproducible training."""
-    mock_app.meta(["ppo", "--seed", "42"], result_action="return_value")
+    mock_app.meta(["ppo", "--seed", "42"], result_action="return_value", exit_on_error=False)
 
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -256,6 +262,7 @@ def test_ppo_custom_algorithm_parameters(mock_app, mock_main):
     mock_app.meta(
         ["ppo", "--gae-lambda", "0.90", "--clip-param", "0.3", "--no-use-gae"],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -270,7 +277,7 @@ def test_ppo_custom_algorithm_parameters(mock_app, mock_main):
 
 def test_sac_default_arguments(mock_app, mock_main):
     """Test SAC command with default arguments."""
-    mock_app.meta(["sac"], result_action="return_value")
+    mock_app.meta(["sac"], result_action="return_value", exit_on_error=False)
 
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -298,6 +305,7 @@ def test_sac_custom_parameters(mock_app, mock_main):
             "--no-twin-q",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -313,7 +321,7 @@ def test_sac_custom_parameters(mock_app, mock_main):
 
 def test_impala_default_arguments(mock_app, mock_main):
     """Test IMPALA command with default arguments."""
-    mock_app.meta(["impala"], result_action="return_value")
+    mock_app.meta(["impala"], result_action="return_value", exit_on_error=False)
 
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -337,6 +345,7 @@ def test_impala_custom_parameters(mock_app, mock_main):
             "1.5",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -366,6 +375,7 @@ def test_resource_settings(mock_app, mock_main):
             "1",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -396,6 +406,7 @@ def test_network_architecture_settings(mock_app, mock_main):
             "256",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -425,6 +436,7 @@ def test_logging_settings(mock_app, mock_main):
     mock_app.meta(
         ["ppo", "--schola-verbosity", "2", "--rllib-verbosity", "3"],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -451,6 +463,7 @@ def test_checkpoint_settings(mock_app, mock_main, tmp_path):
             "--export-onnx",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -471,6 +484,7 @@ def test_ppo_with_executable_simulator(mock_app, mock_main, tmp_path):
     mock_app.meta(
         ["ppo", "executable", "--executable-path", str(executable_path), "--headless"],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -498,6 +512,7 @@ def test_executable_num_simulators_parsed(mock_app, mock_main, tmp_path):
             "4",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -520,6 +535,7 @@ def test_project_num_simulators_parsed(mock_app, mock_main, tmp_path):
             "2",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -531,7 +547,7 @@ def test_project_num_simulators_parsed(mock_app, mock_main, tmp_path):
 
 def test_protocol_settings(mock_app, mock_main):
     """Test protocol configuration parameters."""
-    mock_app.meta(["ppo", "--port", "12345"], result_action="return_value")
+    mock_app.meta(["ppo", "--port", "12345"], result_action="return_value", exit_on_error=False)
 
     mock_main.assert_called_once()
     args: RllibScriptSettings = mock_main.call_args[0][0]
@@ -542,7 +558,7 @@ def test_protocol_settings(mock_app, mock_main):
 
 def test_ppo_env_options_default_is_empty_dict(mock_app, mock_main):
     """Without ``--env-options.k=v`` the field defaults to an empty dict."""
-    mock_app.meta(["ppo"], result_action="return_value")
+    mock_app.meta(["ppo"], result_action="return_value", exit_on_error=False)
     args: RllibScriptSettings = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {}
 
@@ -556,6 +572,7 @@ def test_ppo_env_options_dotted_syntax(mock_app, mock_main):
             "--env-options.curriculum=easy",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     args: RllibScriptSettings = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {
@@ -616,19 +633,19 @@ def test_options_thread_through_rllib_env_config_recipe(mock_protocol_and_simula
 
 def test_multiple_algorithms_return_different_settings(mock_app, mock_main):
     """Test that different algorithm commands create different settings."""
-    mock_app.meta(["ppo"], result_action="return_value")
+    mock_app.meta(["ppo"], result_action="return_value", exit_on_error=False)
     ppo_args: RllibScriptSettings = deepcopy(mock_main.call_args[0][0])
 
     mock_main.reset_mock()
-    mock_app.meta(["sac"], result_action="return_value")
+    mock_app.meta(["sac"], result_action="return_value", exit_on_error=False)
     sac_args: RllibScriptSettings = deepcopy(mock_main.call_args[0][0])
 
     mock_main.reset_mock()
-    mock_app.meta(["impala"], result_action="return_value")
+    mock_app.meta(["impala"], result_action="return_value", exit_on_error=False)
     impala_args: RllibScriptSettings = deepcopy(mock_main.call_args[0][0])
 
     mock_main.reset_mock()
-    mock_app.meta(["appo"], result_action="return_value")
+    mock_app.meta(["appo"], result_action="return_value", exit_on_error=False)
     appo_args: RllibScriptSettings = deepcopy(mock_main.call_args[0][0])
 
     # Verify different algorithm types are set correctly
@@ -687,6 +704,7 @@ def test_complex_configuration(mock_app, mock_main, tmp_path):
             "50051",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
 
     mock_main.assert_called_once()
@@ -758,4 +776,5 @@ def test_train_cli_with_unreal_editor(
             f"{env_server_port}",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )

--- a/Test/rllib/test_export_to_onnx.py
+++ b/Test/rllib/test_export_to_onnx.py
@@ -498,6 +498,7 @@ class TestExportScript:
         export_onnx_app(
             [str(checkpoint_path), str(export_path)],
             result_action="return_value",
+            exit_on_error=False,
         )
         onnx_model_checker(
             export_path,

--- a/Test/sb3/scripts/test_eval_cli.py
+++ b/Test/sb3/scripts/test_eval_cli.py
@@ -12,7 +12,8 @@ import numpy as np
 import pytest
 from cyclopts import App
 
-from schola.scripts.common.settings import EnvironmentSettings, GrpcProtocolConfig
+from schola.scripts.common.settings import GrpcProtocolConfig
+from schola.scripts.sb3.settings import Sb3EnvironmentSettings
 from schola.scripts.sb3.eval.eval import MetaEvalSB3Command, main as eval_main
 from schola.scripts.sb3.eval.settings import Sb3EvalScriptSettings
 
@@ -58,15 +59,19 @@ def mock_main(mocker):
 def mock_eval_app(mock_main):
     base = App(name="eval", help="Evaluate a trained Stable-Baselines3 policy")
     logger = logging.getLogger(__name__)
-    return MetaEvalSB3Command(base, Sb3EvalScriptSettings, mock_main, logger).make()
-
+    class TestEvalSB3Command(MetaEvalSB3Command):
+    
+        @property
+        def main_func(self):
+            return mock_main
+    return TestEvalSB3Command(base, logger).make()
 
 @pytest.fixture
 def sb3_eval_meta_app():
     """Real ``schola sb3 eval`` Cyclopts meta-app (invokes ``eval_main``)."""
     base = App(name="eval", help="Evaluate a trained Stable-Baselines3 policy")
     logger = logging.getLogger(__name__)
-    return MetaEvalSB3Command(base, Sb3EvalScriptSettings, eval_main, logger).make()
+    return MetaEvalSB3Command(base, logger).make()
 
 
 def test_eval_cli_forwards_checkpoint_and_defaults(
@@ -75,7 +80,9 @@ def test_eval_cli_forwards_checkpoint_and_defaults(
     checkpoint = tmp_path / "policy.zip"
     checkpoint.write_bytes(b"x")
     mock_eval_app.meta(
-        ["ppo", "--checkpoint", str(checkpoint)], result_action="return_value"
+        ["ppo", "--checkpoint", str(checkpoint)],
+        result_action="return_value",
+        exit_on_error=False,
     )
     mock_main.assert_called_once()
     args = mock_main.call_args[0][0]
@@ -98,6 +105,7 @@ def test_eval_cli_custom_episodes(mock_eval_app, mock_main, tmp_path: Path):
             "--no-deterministic",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     args = mock_main.call_args[0][0]
     assert args.n_eval_episodes == 3
@@ -112,6 +120,7 @@ def test_eval_cli_env_options_default_is_empty_dict(
     mock_eval_app.meta(
         ["ppo", "--checkpoint", str(checkpoint)],
         result_action="return_value",
+        exit_on_error=False,
     )
     args = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {}
@@ -129,6 +138,7 @@ def test_eval_cli_env_options_dotted_syntax(mock_eval_app, mock_main, tmp_path: 
             "--env-options.curriculum=easy",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     args = mock_main.call_args[0][0]
     assert args.environment_settings.env_options == {
@@ -145,7 +155,7 @@ def test_sb3_eval_main_on_real_vec_env(dummy_sb3_policy_zip, make_vec_env_server
     args = Sb3EvalScriptSettings(
         checkpoint=dummy_sb3_policy_zip,
         n_eval_episodes=2,
-        environment_settings=EnvironmentSettings(
+        environment_settings=Sb3EnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(url="localhost", port=port),
         ),
     )
@@ -175,6 +185,7 @@ def test_sb3_eval_cli_on_real_vec_env(
             "2",
         ],
         result_action="return_value",
+        exit_on_error=False,
     )
     assert math.isfinite(mean_r) and math.isfinite(std_r)
 
@@ -231,7 +242,7 @@ def make_eval_args(tmp_path: Path):
         return Sb3EvalScriptSettings(
             checkpoint=checkpoint,
             n_eval_episodes=n_eval_episodes,
-            environment_settings=EnvironmentSettings(
+            environment_settings=Sb3EnvironmentSettings(
                 protocol_settings=GrpcProtocolConfig(url="localhost", port=1),
                 env_options=env_options or {},
             ),

--- a/Test/sb3/scripts/test_train_cli.py
+++ b/Test/sb3/scripts/test_train_cli.py
@@ -20,8 +20,8 @@ from schola.scripts.common.settings import (
     UnrealExecutableSimulatorConfig,
     UnrealProjectSimulatorConfig,
     ActivationFunctionEnum,
-    EnvironmentSettings,
 )
+from schola.scripts.sb3.settings import Sb3EnvironmentSettings
 
 
 @pytest.mark.parametrize("gym_id", ["CartPole-v1", "MountainCar-v0"])
@@ -32,8 +32,9 @@ def test_launch_script(make_vec_env_server, gym_id):
 
     # Create Sb3ScriptSettings with protocol nested under environment_settings
     args = Sb3TrainScriptSettings(
-        environment_settings=EnvironmentSettings(
-            protocol_settings=GrpcProtocolConfig(port=env_server_port, url="localhost")
+        environment_settings=Sb3EnvironmentSettings(
+            simulator_settings=ExternalSimulatorConfig(num_simulators=1),
+            protocol_settings=GrpcProtocolConfig(port=env_server_port, url="localhost"),
         ),
         algorithm_settings=PPOTrainSettings(),
     )
@@ -47,8 +48,9 @@ def test_launch_script_with_dict_action_space(make_vec_env_server):
         [make_dict_action_env(DictActionBoxEnv, False) for _ in range(N_ENVS)]
     )
     args = Sb3TrainScriptSettings(
-        environment_settings=EnvironmentSettings(
-            protocol_settings=GrpcProtocolConfig(port=env_server_port, url="localhost")
+        environment_settings=Sb3EnvironmentSettings(
+            simulator_settings=ExternalSimulatorConfig(num_simulators=1),
+            protocol_settings=GrpcProtocolConfig(port=env_server_port, url="localhost"),
         ),
         algorithm_settings=PPOTrainSettings(),
     )
@@ -68,7 +70,17 @@ def mock_app(mock_main):
     # mock the main method
     app = App(name="train", help="Train a model using StableBaselines3")
     logger = logging.getLogger(__name__)
-    app = MetaTrainSB3Command(app, Sb3TrainScriptSettings, mock_main, logger).make()
+    
+    class TestTrainSB3Command(MetaTrainSB3Command):
+        @property
+        def main_func(self):
+            return mock_main
+
+        @property
+        def script_args_type(self):
+            return Sb3TrainScriptSettings
+        
+    app = TestTrainSB3Command(app, logger).make()
     return app.meta
 
 

--- a/Test/sb3/scripts/test_train_main.py
+++ b/Test/sb3/scripts/test_train_main.py
@@ -15,7 +15,8 @@ import pytest
 from cyclopts import App
 from stable_baselines3.common.callbacks import CheckpointCallback
 
-from schola.scripts.common.settings import EnvironmentSettings, GrpcProtocolConfig
+from schola.scripts.common.settings import GrpcProtocolConfig
+from schola.scripts.sb3.settings import Sb3EnvironmentSettings
 from schola.scripts.sb3.train.settings import (
     PPOTrainSettings,
     SACTrainSettings,
@@ -41,11 +42,13 @@ def mock_main(mocker):
 def mock_app(mock_main):
     app_obj = App(name="train", help="Train a model using StableBaselines3")
     logger = logging.getLogger("test_train_main_branches")
-    return (
-        MetaTrainSB3Command(app_obj, Sb3TrainScriptSettings, mock_main, logger)
-        .make()
-        .meta
-    )
+
+    class TestTrainSB3Command(MetaTrainSB3Command):
+        @property
+        def main_func(self):
+            return mock_main
+
+    return TestTrainSB3Command(app_obj, logger).make().meta
 
 
 @pytest.fixture(scope="function")
@@ -129,7 +132,7 @@ def _train_args(
     )
 
     return Sb3TrainScriptSettings(
-        environment_settings=EnvironmentSettings(
+        environment_settings=Sb3EnvironmentSettings(
             protocol_settings=GrpcProtocolConfig(port=1, url="localhost"),
             env_options=env_options or {},
             seed=seed,

--- a/Test/sb3/test_export_to_onnx.py
+++ b/Test/sb3/test_export_to_onnx.py
@@ -272,6 +272,7 @@ class TestExportScript:
                 params.algo_name.upper(),
             ],
             result_action="return_value",
+            exit_on_error=False,
         )
 
         onnx_model_checker(
@@ -312,6 +313,7 @@ class TestExportScript:
                 params.algo_name.upper(),
             ],
             result_action="return_value",
+            exit_on_error=False,
         )
         onnx_model_checker(
             tmp_path / "test.onnx",
@@ -344,6 +346,7 @@ class TestExportScript:
                 params.algo_name.upper(),
             ],
             result_action="return_value",
+            exit_on_error=False,
         )
         # Check that the action space is the same as the merged action space, since the original shape wasn't provided
         onnx_model_checker(

--- a/Test/scripts/test_command_template.py
+++ b/Test/scripts/test_command_template.py
@@ -48,7 +48,11 @@ class FakeAlgoBeta:
 class FakeScriptSettings:
     """Minimal script container compatible with ``ScholaCommandTemplate`` wiring."""
 
-    environment_settings: EnvironmentSettings = field(default_factory=EnvironmentSettings)
+    environment_settings: EnvironmentSettings = field(
+        default_factory=lambda: EnvironmentSettings(
+            simulator_settings=ExternalSimulatorConfig()
+        )
+    )
 
     algorithm_settings: Annotated[
         Union[FakeAlgoAlpha, FakeAlgoBeta], Parameter(show=False, parse=False)
@@ -71,6 +75,7 @@ FULL_SIMULATOR_KEYS: tuple[str, ...] = tuple(FULL_SIMULATOR_TABLE.keys())
 def _make_meta_alg_command_class(
     algorithm_keys: tuple[str, ...],
     simulator_keys: tuple[str, ...],
+    mock_main: MagicMock,
 ) -> Type[ScholaCommandTemplate[FakeScriptSettings]]:
     """Build a ``ScholaCommandTemplate`` subclass with a chosen number of algorithms / simulators."""
 
@@ -90,6 +95,14 @@ def _make_meta_alg_command_class(
         def simulator_table(self) -> Dict[str, Type[Any]]:
             return sim_table
 
+        @property
+        def script_args_type(self) -> Type[FakeScriptSettings]:
+            return FakeScriptSettings
+
+        @property
+        def main_func(self):
+            return mock_main
+
     return _DynamicScholaCommandTemplate
 
 
@@ -104,24 +117,8 @@ def _build_meta_alg_app(
     logger = logging.getLogger(f"test_command_template.{app_name}")
     if not logger.handlers:
         logger.addHandler(logging.NullHandler())
-    cls = _make_meta_alg_command_class(algorithm_keys, simulator_keys)
-    return cls(app, FakeScriptSettings, mock_main, logger).make().meta
-
-
-class FakeScholaCommandTemplate(ScholaCommandTemplate[FakeScriptSettings]):
-    @property
-    def algorithm_table(self) -> Dict[str, Type[Any]]:
-        return {
-            "alpha": FakeAlgoAlpha,
-            "beta": FakeAlgoBeta,
-        }
-
-    @property
-    def algorithm_help(self) -> Dict[str, str]:
-        return {
-            "alpha": "Fake algorithm alpha (tests).",
-            "beta": "Fake algorithm beta (tests).",
-        }
+    cls = _make_meta_alg_command_class(algorithm_keys, simulator_keys, mock_main)
+    return cls(app, logger).make().meta
 
 
 @pytest.fixture
@@ -135,7 +132,12 @@ def meta_app(mock_main: MagicMock):
     app = App(name="train-fake", help="Fake train CLI for template tests")
     logger = logging.getLogger("test_command_template")
     logger.addHandler(logging.NullHandler())
-    built = FakeScholaCommandTemplate(app, FakeScriptSettings, mock_main, logger).make()
+    cls = _make_meta_alg_command_class(
+        ("alpha", "beta"),
+        FULL_SIMULATOR_KEYS,
+        mock_main,
+    )
+    built = cls(app, logger).make()
     # ``make()`` returns ``app.meta``; config YAML handling lives on ``app.meta.meta.default``.
     return built.meta
 
@@ -146,19 +148,12 @@ def no_alg_meta_app(mock_main: MagicMock):
     app = App(name="train-no-alg-fake", help="Fake no-algorithm train CLI")
     logger = logging.getLogger("test_command_template_no_alg")
     logger.addHandler(logging.NullHandler())
-    class FakeScholaCommand(ScholaCommandTemplate[FakeScriptSettings]):
-        @property
-        def simulator_table(self) -> Dict[str, Type[Any]]:
-            return {
-                "executable": UnrealExecutableSimulatorConfig,
-                "external": ExternalSimulatorConfig,
-            }
-
-        @property
-        def algorithm_table(self) -> Dict[str, Type[Any]]:
-            return {}
-
-    built = FakeScholaCommand(app, FakeScriptSettings, mock_main, logger).make()
+    cls = _make_meta_alg_command_class(
+        (),
+        ("executable", "external"),
+        mock_main,
+    )
+    built = cls(app, logger).make()
     return built.meta
 
 def test_yaml_split_meta_no_alg_config_handler():

--- a/Test/scripts/test_command_template.py
+++ b/Test/scripts/test_command_template.py
@@ -14,9 +14,11 @@ import yaml
 from cyclopts import App, Parameter, validators
 
 from schola.scripts.common.settings import (
+    AllSimulatorConfigs,
     EnvironmentSettings,
     ExternalSimulatorConfig,
     GrpcProtocolConfig,
+    IgnoreParameter,
     UnrealExecutableSimulatorConfig,
     UnrealProjectSimulatorConfig,
 )
@@ -43,15 +45,17 @@ class FakeAlgoBeta:
 
     beta_steps: Annotated[int, Parameter(validator=validators.Number(gte=1))] = 11
 
+@dataclass
+class FakeEnvironmentSettings(EnvironmentSettings[AllSimulatorConfigs]):
+    """Fake environment settings for testing."""
+    simulator_settings: Annotated[AllSimulatorConfigs, IgnoreParameter] = field(default_factory=ExternalSimulatorConfig)
 
 @dataclass
 class FakeScriptSettings:
     """Minimal script container compatible with ``ScholaCommandTemplate`` wiring."""
 
-    environment_settings: EnvironmentSettings = field(
-        default_factory=lambda: EnvironmentSettings(
-            simulator_settings=ExternalSimulatorConfig()
-        )
+    environment_settings: FakeEnvironmentSettings = field(
+        default_factory=FakeEnvironmentSettings
     )
 
     algorithm_settings: Annotated[
@@ -469,7 +473,7 @@ _META_ALG_CLI_ALGORITHM_SIMULATOR_COUNT_MATRIX: tuple[MetaAlgCliTestParameters, 
             _EXE_PLACEHOLDER,
         ],
         expected_sim_settings=FakeScriptSettings(
-            environment_settings=EnvironmentSettings(
+            environment_settings=FakeEnvironmentSettings(
                 simulator_settings=UnrealExecutableSimulatorConfig(
                     executable_path=Path(_EXE_PLACEHOLDER),
                 ),


### PR DESCRIPTION
## Summary

Improved typing of Simulators, Protocols and associated Configs. 

Note that EnvironmentSettings objects can no longer be created directly and should be subclassed moving forward.


## Type of change

- [x] Refactor or internal cleanup

## Changes

- Added a new structural type for organizing spawn behavior.
- Added a new baseclass for simulator CLI configuration objects with typed and standardized make methods. 
- Made EnvironmentSettings generic with a subtype per script to handle typing for scripts that don't support all Simulators gracefully.
- reorganized CommandTemplate to have a more coherent split between constructor-args and subclass properties.

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
