### PR TITLE
chore: add additional camera tests and support for tests requiring rendering

### DIFF
--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
@@ -75,6 +75,29 @@ bool FCameraSensorCapture_AfterInitSensor_Test::RunTest(const FString& Parameter
 	TestTrue(TEXT("CollectObservations succeeds after InitSensor"), Observations.GetScriptStruct() == FBoxPoint::StaticStruct());
 	TestTrue(TEXT("Collected values populated"), Observations.Get<FBoxPoint>().Values.Num() > 0);
 
+	// Spatial checks: InitSensor allocates a 128x128 target and FinalColorLDR yields RGB (3 channels).
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+	const int32 Width = 128;
+	const int32 Height = 128;
+	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("AfterInitSensor"));
+
+	// The green cube sits directly ahead of the camera, so it projects to the centre of the frame.
+	const FIntRect CenterRegion(Width * 7 / 16, Height * 7 / 16, Width * 9 / 16, Height * 9 / 16);
+	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
+	constexpr int32 RedChannel = 0;
+	constexpr int32 GreenChannel = 1;
+	constexpr int32 BlueChannel = 2;
+
+	// Centre (cube) should be noticeably greener than the empty background corner.
+	AssertBoxPointRegionBrighter(*this, BoxPoint, GreenChannel, CenterRegion, CornerRegion, Width, Height, 0.05f, TEXT("AfterInitSensor green centre vs corner"));
+
+	// Green should dominate red/blue where the green cube is rendered.
+	const float CenterR = ComputeBoxPointRegionMean(BoxPoint, RedChannel, CenterRegion, Width, Height);
+	const float CenterG = ComputeBoxPointRegionMean(BoxPoint, GreenChannel, CenterRegion, Width, Height);
+	const float CenterB = ComputeBoxPointRegionMean(BoxPoint, BlueChannel, CenterRegion, Width, Height);
+	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds red %.3f"), CenterG, CenterR), CenterG > CenterR);
+	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds blue %.3f"), CenterG, CenterB), CenterG > CenterB);
+
 	return true;
 }
 
@@ -111,6 +134,14 @@ bool FCameraSensorCapture_ObsSpaceMatchesCollect_Test::RunTest(const FString& Pa
 
 	TestEqual(TEXT("Collected shape matches observation space"), BoxPoint.Shape, Space.Shape);
 	TestEqual(TEXT("Collected value count matches space dimensions"), BoxPoint.Values.Num(), Space.Dimensions.Num());
+
+	// Spatial check: the orange cube (strong red) sits centre-frame, so the centre should be
+	// clearly redder than the empty background corner.
+	const int32 Width = 32;
+	const int32 Height = 32;
+	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
+	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
+	AssertBoxPointRegionBrighter(*this, BoxPoint, 0, CenterRegion, CornerRegion, Width, Height, 0.05f, TEXT("ObsSpaceMatchesCollect orange centre vs corner"));
 
 	return true;
 }
@@ -163,6 +194,19 @@ bool FCameraSensorCapture_DepthMode_Test::RunTest(const FString& Parameters)
 	const float CenterDepth = GetBoxPointChannelValue(BoxPoint, 0, Height / 2, Width / 2, Width, Height);
 	TestTrue(TEXT("Center depth value should be populated"), CenterDepth > 0.0f && CenterDepth <= 1.0f);
 
+	// Spatial check: the cubes occupy the centre of the frame while the corners see empty background,
+	// so the centre depth should be measurably different from the background corners.
+	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
+	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
+	const float CenterDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CenterRegion, Width, Height);
+	const float CornerDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CornerRegion, Width, Height);
+	TestTrue(
+		FString::Printf(
+			TEXT("Centre depth (%.4f) should differ from background corner depth (%.4f)"),
+			CenterDepthMean,
+			CornerDepthMean),
+		!FMath::IsNearlyEqual(CenterDepthMean, CornerDepthMean, 0.02f));
+
 	return true;
 }
 
@@ -206,6 +250,64 @@ bool FCameraSensorCapture_ResolutionChange_Test::RunTest(const FString& Paramete
 	TestEqual(TEXT("32x32 value count"), Values32, 3 * 32 * 32);
 	TestEqual(TEXT("64x64 value count"), Values64, 3 * 64 * 64);
 	TestTrue(TEXT("Higher resolution produces more values"), Values64 > Values32);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorCapture_SpatialLocalization_Test,
+	"Schola.Sensors.CameraSensor.Capture.SpatialLocalization",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorCapture_SpatialLocalization_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	SpawnDirectionalLight(World);
+
+	// Camera faces +X; its right vector is +Y, which maps to the right (higher column) side of the image.
+	UCameraSensor* Sensor = SpawnCameraSensor(World, FVector(-400.0f, 0.0f, 0.0f), FRotator::ZeroRotator, 64, 64);
+	TestNotNull(TEXT("Camera sensor spawned"), Sensor);
+	if (!Sensor)
+	{
+		return false;
+	}
+
+	// Offset the green cube to +Y so it should render in the right half of the frame.
+	SpawnColoredCube(World, FVector(0.0f, 150.0f, 0.0f), FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
+
+	for (int32 i = 0; i < 5; ++i)
+	{
+		TestWorld.Tick(0.016f);
+	}
+
+	FInstancedStruct Observations;
+	CaptureAndCollect(Sensor, TestWorld, Observations);
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+
+	const int32 Width = 64;
+	const int32 Height = 64;
+	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("SpatialLocalization"));
+
+	constexpr int32 GreenChannel = 1;
+	const FIntRect RightHalf(Width / 2, 0, Width, Height);
+	const FIntRect LeftHalf(0, 0, Width / 2, Height);
+
+	// The +Y cube should localise to the right half of the image, leaving the left half dark.
+	AssertBoxPointRegionBrighter(
+		*this,
+		BoxPoint,
+		GreenChannel,
+		RightHalf,
+		LeftHalf,
+		Width,
+		Height,
+		0.05f,
+		TEXT("SpatialLocalization +Y cube on right"));
 
 	return true;
 }

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
@@ -89,12 +89,12 @@ bool FCameraSensorCapture_AfterInitSensor_Test::RunTest(const FString& Parameter
 	constexpr int32 BlueChannel = 2;
 
 	// Centre (cube) should be noticeably greener than the empty background corner.
-	AssertBoxPointRegionBrighter(*this, BoxPoint, GreenChannel, CenterRegion, CornerRegion, Width, Height, 0.05f, TEXT("AfterInitSensor green centre vs corner"));
+	AssertBoxPointRegionBrighter(*this, BoxPoint, GreenChannel, CenterRegion, CornerRegion, 0.05f, TEXT("AfterInitSensor green centre vs corner"));
 
 	// Green should dominate red/blue where the green cube is rendered.
-	const float CenterR = ComputeBoxPointRegionMean(BoxPoint, RedChannel, CenterRegion, Width, Height);
-	const float CenterG = ComputeBoxPointRegionMean(BoxPoint, GreenChannel, CenterRegion, Width, Height);
-	const float CenterB = ComputeBoxPointRegionMean(BoxPoint, BlueChannel, CenterRegion, Width, Height);
+	const float CenterR = ComputeBoxPointRegionMean(BoxPoint, RedChannel, CenterRegion);
+	const float CenterG = ComputeBoxPointRegionMean(BoxPoint, GreenChannel, CenterRegion);
+	const float CenterB = ComputeBoxPointRegionMean(BoxPoint, BlueChannel, CenterRegion);
 	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds red %.3f"), CenterG, CenterR), CenterG > CenterR);
 	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds blue %.3f"), CenterG, CenterB), CenterG > CenterB);
 
@@ -141,7 +141,7 @@ bool FCameraSensorCapture_ObsSpaceMatchesCollect_Test::RunTest(const FString& Pa
 	const int32 Height = 32;
 	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
 	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
-	AssertBoxPointRegionBrighter(*this, BoxPoint, 0, CenterRegion, CornerRegion, Width, Height, 0.05f, TEXT("ObsSpaceMatchesCollect orange centre vs corner"));
+	AssertBoxPointRegionBrighter(*this, BoxPoint, 0, CenterRegion, CornerRegion, 0.05f, TEXT("ObsSpaceMatchesCollect orange centre vs corner"));
 
 	return true;
 }
@@ -191,15 +191,15 @@ bool FCameraSensorCapture_DepthMode_Test::RunTest(const FString& Parameters)
 	const int32 Height = 64;
 	AssertBoxPointShape(*this, BoxPoint, 1, Height, Width, TEXT("DepthMode"));
 
-	const float CenterDepth = GetBoxPointChannelValue(BoxPoint, 0, Height / 2, Width / 2, Width, Height);
+	const float CenterDepth = GetBoxPointChannelValue(BoxPoint, 0, Height / 2, Width / 2);
 	TestTrue(TEXT("Center depth value should be populated"), CenterDepth > 0.0f && CenterDepth <= 1.0f);
 
 	// Spatial check: the cubes occupy the centre of the frame while the corners see empty background,
 	// so the centre depth should be measurably different from the background corners.
 	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
 	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
-	const float CenterDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CenterRegion, Width, Height);
-	const float CornerDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CornerRegion, Width, Height);
+	const float CenterDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CenterRegion);
+	const float CornerDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CornerRegion);
 	TestTrue(
 		FString::Printf(
 			TEXT("Centre depth (%.4f) should differ from background corner depth (%.4f)"),
@@ -304,8 +304,6 @@ bool FCameraSensorCapture_SpatialLocalization_Test::RunTest(const FString& Param
 		GreenChannel,
 		RightHalf,
 		LeftHalf,
-		Width,
-		Height,
 		0.05f,
 		TEXT("SpatialLocalization +Y cube on right"));
 

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#include "Test/Sensors/CameraSensorTestHelpers.h"
+
+#include "Sensors/CameraSensor.h"
+#include "Engine/DirectionalLight.h"
+#include "Engine/StaticMesh.h"
+#include "Points/BoxPoint.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+using namespace ScholaCameraSensorTest;
+
+static void SpawnDirectionalLight(UWorld* World)
+{
+	if (!World)
+	{
+		return;
+	}
+
+	FActorSpawnParameters SpawnParams;
+	SpawnParams.ObjectFlags = RF_Transient;
+	World->SpawnActor<ADirectionalLight>(FVector(0.0f, 0.0f, 500.0f), FRotator(-45.0f, 45.0f, 0.0f), SpawnParams);
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorCapture_AfterInitSensor_Test,
+	"Schola.Sensors.CameraSensor.Capture.AfterInitSensor",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorCapture_AfterInitSensor_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	SpawnDirectionalLight(World);
+
+	UCameraSensor* Sensor = SpawnCameraSensor(
+		World,
+		FVector(-400.0f, 0.0f, 0.0f),
+		FRotator::ZeroRotator,
+		64,
+		64,
+		ESceneCaptureSource::SCS_FinalColorLDR,
+		15,
+		false,
+		false);
+	TestNotNull(TEXT("Camera sensor spawned"), Sensor);
+	if (!Sensor)
+	{
+		return false;
+	}
+
+	TestTrue(TEXT("No render target before InitSensor"), Sensor->TextureTarget == nullptr);
+	Sensor->InitSensor_Implementation();
+
+	TestNotNull(TEXT("InitSensor creates render target"), Sensor->TextureTarget.Get());
+	TestEqual(TEXT("InitSensor default width"), static_cast<int32>(Sensor->TextureTarget->GetSurfaceWidth()), 128);
+	TestEqual(TEXT("InitSensor default height"), static_cast<int32>(Sensor->TextureTarget->GetSurfaceHeight()), 128);
+	TestTrue(TEXT("InitSensor sets GPU shared flag"), Sensor->TextureTarget->bGPUSharedFlag);
+
+	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
+	for (int32 i = 0; i < 5; ++i)
+	{
+		TestWorld.Tick(0.016f);
+	}
+
+	FInstancedStruct Observations;
+	CaptureAndCollect(Sensor, TestWorld, Observations);
+	TestTrue(TEXT("CollectObservations succeeds after InitSensor"), Observations.GetScriptStruct() == FBoxPoint::StaticStruct());
+	TestTrue(TEXT("Collected values populated"), Observations.Get<FBoxPoint>().Values.Num() > 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorCapture_ObsSpaceMatchesCollect_Test,
+	"Schola.Sensors.CameraSensor.Capture.ObsSpaceMatchesCollect",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorCapture_ObsSpaceMatchesCollect_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	SpawnDirectionalLight(World);
+
+	UCameraSensor* Sensor = SpawnCameraSensor(World, FVector(-400.0f, 0.0f, 0.0f), FRotator::ZeroRotator, 32, 32);
+	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(1.0f, 0.5f, 0.0f, 1.0f));
+
+	for (int32 i = 0; i < 5; ++i)
+	{
+		TestWorld.Tick(0.016f);
+	}
+
+	FInstancedStruct ObservationSpace;
+	Sensor->GetObservationSpace_Implementation(ObservationSpace);
+	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
+
+	FInstancedStruct Observations;
+	CaptureAndCollect(Sensor, TestWorld, Observations);
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+
+	TestEqual(TEXT("Collected shape matches observation space"), BoxPoint.Shape, Space.Shape);
+	TestEqual(TEXT("Collected value count matches space dimensions"), BoxPoint.Values.Num(), Space.Dimensions.Num());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorCapture_DepthMode_Test,
+	"Schola.Sensors.CameraSensor.Capture.DepthMode",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorCapture_DepthMode_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	SpawnDirectionalLight(World);
+
+	UCameraSensor* Sensor = SpawnCameraSensor(
+		World,
+		FVector(-600.0f, 0.0f, 0.0f),
+		FRotator::ZeroRotator,
+		64,
+		64,
+		ESceneCaptureSource::SCS_SceneDepth,
+		15);
+	TestNotNull(TEXT("Camera sensor spawned"), Sensor);
+	if (!Sensor)
+	{
+		return false;
+	}
+
+	SpawnColoredCube(World, FVector(-100.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f), FVector(150.0f));
+	SpawnColoredCube(World, FVector(200.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f), FVector(150.0f));
+
+	for (int32 i = 0; i < 5; ++i)
+	{
+		TestWorld.Tick(0.016f);
+	}
+
+	FInstancedStruct Observations;
+	CaptureAndCollect(Sensor, TestWorld, Observations);
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+
+	const int32 Width = 64;
+	const int32 Height = 64;
+	AssertBoxPointShape(*this, BoxPoint, 1, Height, Width, TEXT("DepthMode"));
+
+	const float CenterDepth = GetBoxPointChannelValue(BoxPoint, 0, Height / 2, Width / 2, Width, Height);
+	TestTrue(TEXT("Center depth value should be populated"), CenterDepth > 0.0f && CenterDepth <= 1.0f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorCapture_ResolutionChange_Test,
+	"Schola.Sensors.CameraSensor.Capture.ResolutionChange",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorCapture_ResolutionChange_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	SpawnDirectionalLight(World);
+	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(1.0f, 0.0f, 0.0f, 1.0f));
+
+	auto RunCaptureAtResolution = [&](int32 Resolution) -> int32
+	{
+		UCameraSensor* Sensor = SpawnCameraSensor(
+			World,
+			FVector(-400.0f, 0.0f, 0.0f),
+			FRotator::ZeroRotator,
+			Resolution,
+			Resolution);
+		for (int32 i = 0; i < 3; ++i)
+		{
+			TestWorld.Tick(0.016f);
+		}
+
+		FInstancedStruct Observations;
+		CaptureAndCollect(Sensor, TestWorld, Observations);
+		return Observations.Get<FBoxPoint>().Values.Num();
+	};
+
+	const int32 Values32 = RunCaptureAtResolution(32);
+	const int32 Values64 = RunCaptureAtResolution(64);
+
+	TestEqual(TEXT("32x32 value count"), Values32, 3 * 32 * 32);
+	TestEqual(TEXT("64x64 value count"), Values64, 3 * 64 * 64);
+	TestTrue(TEXT("Higher resolution produces more values"), Values64 > Values32);
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorCaptureTest.cpp
@@ -13,6 +13,23 @@
 
 using namespace ScholaCameraSensorTest;
 
+/**
+ * Scene-validation strategies used in this file:
+ *
+ * - Baseline + single cube: capture an empty scene, spawn one coloured cube, capture again,
+ *   and assert the expected channel rose vs baseline in a fixed region. Used by AfterInitSensor
+ *   and ObsSpaceMatchesCollect.
+ *
+ * - Sequential two-colour: baseline capture, then spawn cube A and assert, destroy A, spawn
+ *   cube B at a different location/colour and assert. Proves capture tracks scene changes and
+ *   that colour localises to the expected image region. Used only by SpatialLocalization.
+ *
+ * - Side-by-side cubes: baseline capture, then spawn multiple cubes in one pass before the
+ *   second capture. Used by DepthMode (two grey cubes along +X for centre depth geometry).
+ *
+ * ResolutionChange does not perform spatial/channel validation; it only checks value counts.
+ */
+
 static void SpawnDirectionalLight(UWorld* World)
 {
 	if (!World)
@@ -64,39 +81,49 @@ bool FCameraSensorCapture_AfterInitSensor_Test::RunTest(const FString& Parameter
 	TestEqual(TEXT("InitSensor default height"), static_cast<int32>(Sensor->TextureTarget->GetSurfaceHeight()), 128);
 	TestTrue(TEXT("InitSensor sets GPU shared flag"), Sensor->TextureTarget->bGPUSharedFlag);
 
-	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
-	for (int32 i = 0; i < 5; ++i)
-	{
-		TestWorld.Tick(0.016f);
-	}
+	// Baseline + single cube: empty scene first, then one green cube at the frame centre.
+	const int32 Width = 128;
+	const int32 Height = 128;
+	const FIntRect CenterRegion(Width * 7 / 16, Height * 7 / 16, Width * 9 / 16, Height * 9 / 16);
+	constexpr int32 GreenChannel = 1;
+
+	FInstancedStruct BaselineObservations;
+	CaptureAndCollect(Sensor, TestWorld, BaselineObservations);
+	TestTrue(TEXT("Baseline collect succeeds after InitSensor"), BaselineObservations.GetScriptStruct() == FBoxPoint::StaticStruct());
+	const FBoxPoint& BaselineBoxPoint = BaselineObservations.Get<FBoxPoint>();
+	AssertBoxPointShape(*this, BaselineBoxPoint, 3, Height, Width, TEXT("AfterInitSensor baseline"));
+
+	UStaticMeshComponent* GreenCube = SpawnColoredCube(
+		World,
+		FVector(0.0f, 0.0f, 0.0f),
+		FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
+	TestNotNull(TEXT("Green cube spawned"), GreenCube);
+	SettleScene(TestWorld);
 
 	FInstancedStruct Observations;
 	CaptureAndCollect(Sensor, TestWorld, Observations);
 	TestTrue(TEXT("CollectObservations succeeds after InitSensor"), Observations.GetScriptStruct() == FBoxPoint::StaticStruct());
 	TestTrue(TEXT("Collected values populated"), Observations.Get<FBoxPoint>().Values.Num() > 0);
 
-	// Spatial checks: InitSensor allocates a 128x128 target and FinalColorLDR yields RGB (3 channels).
 	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
-	const int32 Width = 128;
-	const int32 Height = 128;
 	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("AfterInitSensor"));
 
-	// The green cube sits directly ahead of the camera, so it projects to the centre of the frame.
-	const FIntRect CenterRegion(Width * 7 / 16, Height * 7 / 16, Width * 9 / 16, Height * 9 / 16);
-	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
-	constexpr int32 RedChannel = 0;
-	constexpr int32 GreenChannel = 1;
-	constexpr int32 BlueChannel = 2;
+	AssertBoxPointRegionChannelDeltaFromBaseline(
+		*this,
+		BoxPoint,
+		BaselineBoxPoint,
+		GreenChannel,
+		CenterRegion,
+		CaptureSpatialMinChannelDelta,
+		TEXT("AfterInitSensor green centre vs baseline"));
+	AssertBoxPointRegionDominantChannel(
+		*this,
+		BoxPoint,
+		GreenChannel,
+		CenterRegion,
+		TEXT("AfterInitSensor green dominates centre"));
 
-	// Centre (cube) should be noticeably greener than the empty background corner.
-	AssertBoxPointRegionBrighter(*this, BoxPoint, GreenChannel, CenterRegion, CornerRegion, 0.05f, TEXT("AfterInitSensor green centre vs corner"));
-
-	// Green should dominate red/blue where the green cube is rendered.
-	const float CenterR = ComputeBoxPointRegionMean(BoxPoint, RedChannel, CenterRegion);
-	const float CenterG = ComputeBoxPointRegionMean(BoxPoint, GreenChannel, CenterRegion);
-	const float CenterB = ComputeBoxPointRegionMean(BoxPoint, BlueChannel, CenterRegion);
-	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds red %.3f"), CenterG, CenterR), CenterG > CenterR);
-	TestTrue(FString::Printf(TEXT("Centre green %.3f exceeds blue %.3f"), CenterG, CenterB), CenterG > CenterB);
+	DestroyColoredCube(GreenCube, TestWorld);
 
 	return true;
 }
@@ -117,12 +144,23 @@ bool FCameraSensorCapture_ObsSpaceMatchesCollect_Test::RunTest(const FString& Pa
 	SpawnDirectionalLight(World);
 
 	UCameraSensor* Sensor = SpawnCameraSensor(World, FVector(-400.0f, 0.0f, 0.0f), FRotator::ZeroRotator, 32, 32);
-	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(1.0f, 0.5f, 0.0f, 1.0f));
 
-	for (int32 i = 0; i < 5; ++i)
-	{
-		TestWorld.Tick(0.016f);
-	}
+	// Baseline + single cube: empty scene first, then one orange cube at the frame centre.
+	const int32 Width = 32;
+	const int32 Height = 32;
+	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
+	constexpr int32 RedChannel = 0;
+
+	FInstancedStruct BaselineObservations;
+	CaptureAndCollect(Sensor, TestWorld, BaselineObservations);
+	const FBoxPoint& BaselineBoxPoint = BaselineObservations.Get<FBoxPoint>();
+
+	UStaticMeshComponent* OrangeCube = SpawnColoredCube(
+		World,
+		FVector(0.0f, 0.0f, 0.0f),
+		FLinearColor(1.0f, 0.5f, 0.0f, 1.0f));
+	TestNotNull(TEXT("Orange cube spawned"), OrangeCube);
+	SettleScene(TestWorld);
 
 	FInstancedStruct ObservationSpace;
 	Sensor->GetObservationSpace_Implementation(ObservationSpace);
@@ -135,13 +173,22 @@ bool FCameraSensorCapture_ObsSpaceMatchesCollect_Test::RunTest(const FString& Pa
 	TestEqual(TEXT("Collected shape matches observation space"), BoxPoint.Shape, Space.Shape);
 	TestEqual(TEXT("Collected value count matches space dimensions"), BoxPoint.Values.Num(), Space.Dimensions.Num());
 
-	// Spatial check: the orange cube (strong red) sits centre-frame, so the centre should be
-	// clearly redder than the empty background corner.
-	const int32 Width = 32;
-	const int32 Height = 32;
-	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
-	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
-	AssertBoxPointRegionBrighter(*this, BoxPoint, 0, CenterRegion, CornerRegion, 0.05f, TEXT("ObsSpaceMatchesCollect orange centre vs corner"));
+	AssertBoxPointRegionChannelDeltaFromBaseline(
+		*this,
+		BoxPoint,
+		BaselineBoxPoint,
+		RedChannel,
+		CenterRegion,
+		CaptureSpatialMinChannelDelta,
+		TEXT("ObsSpaceMatchesCollect red centre vs baseline"));
+	AssertBoxPointRegionDominantChannel(
+		*this,
+		BoxPoint,
+		RedChannel,
+		CenterRegion,
+		TEXT("ObsSpaceMatchesCollect red dominates centre"));
+
+	DestroyColoredCube(OrangeCube, TestWorld);
 
 	return true;
 }
@@ -175,37 +222,36 @@ bool FCameraSensorCapture_DepthMode_Test::RunTest(const FString& Parameters)
 		return false;
 	}
 
-	SpawnColoredCube(World, FVector(-100.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f), FVector(150.0f));
-	SpawnColoredCube(World, FVector(200.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f), FVector(150.0f));
+	// Side-by-side cubes: baseline with no geometry, then two cubes spawned together along +X.
+	const int32 Width = 64;
+	const int32 Height = 64;
+	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
 
-	for (int32 i = 0; i < 5; ++i)
-	{
-		TestWorld.Tick(0.016f);
-	}
+	FInstancedStruct BaselineObservations;
+	CaptureAndCollect(Sensor, TestWorld, BaselineObservations);
+	const FBoxPoint& BaselineBoxPoint = BaselineObservations.Get<FBoxPoint>();
+
+	SpawnColoredCube(World, FVector(-50.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f));
+	SpawnColoredCube(World, FVector(50.0f, 0.0f, 0.0f), FLinearColor(0.5f, 0.5f, 0.5f, 1.0f));
+	SettleScene(TestWorld);
 
 	FInstancedStruct Observations;
 	CaptureAndCollect(Sensor, TestWorld, Observations);
 	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
 
-	const int32 Width = 64;
-	const int32 Height = 64;
 	AssertBoxPointShape(*this, BoxPoint, 1, Height, Width, TEXT("DepthMode"));
 
 	const float CenterDepth = GetBoxPointChannelValue(BoxPoint, 0, Height / 2, Width / 2);
 	TestTrue(TEXT("Center depth value should be populated"), CenterDepth > 0.0f && CenterDepth <= 1.0f);
 
-	// Spatial check: the cubes occupy the centre of the frame while the corners see empty background,
-	// so the centre depth should be measurably different from the background corners.
-	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
-	const FIntRect CornerRegion(0, 0, Width / 8, Height / 8);
 	const float CenterDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CenterRegion);
-	const float CornerDepthMean = ComputeBoxPointRegionMean(BoxPoint, 0, CornerRegion);
+	const float BaselineCenterDepthMean = ComputeBoxPointRegionMean(BaselineBoxPoint, 0, CenterRegion);
 	TestTrue(
 		FString::Printf(
-			TEXT("Centre depth (%.4f) should differ from background corner depth (%.4f)"),
+			TEXT("Centre depth (%.4f) should differ from baseline centre depth (%.4f)"),
 			CenterDepthMean,
-			CornerDepthMean),
-		!FMath::IsNearlyEqual(CenterDepthMean, CornerDepthMean, 0.02f));
+			BaselineCenterDepthMean),
+		!FMath::IsNearlyEqual(CenterDepthMean, BaselineCenterDepthMean, 0.02f));
 
 	return true;
 }
@@ -224,6 +270,7 @@ bool FCameraSensorCapture_ResolutionChange_Test::RunTest(const FString& Paramete
 
 	UWorld* World = TestWorld.GetWorld();
 	SpawnDirectionalLight(World);
+	// No baseline or spatial validation; a cube is present only so captures are non-empty.
 	SpawnColoredCube(World, FVector(0.0f, 0.0f, 0.0f), FLinearColor(1.0f, 0.0f, 0.0f, 1.0f));
 
 	auto RunCaptureAtResolution = [&](int32 Resolution) -> int32
@@ -277,35 +324,89 @@ bool FCameraSensorCapture_SpatialLocalization_Test::RunTest(const FString& Param
 		return false;
 	}
 
-	// Offset the green cube to +Y so it should render in the right half of the frame.
-	SpawnColoredCube(World, FVector(0.0f, 150.0f, 0.0f), FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
-
-	for (int32 i = 0; i < 5; ++i)
-	{
-		TestWorld.Tick(0.016f);
-	}
-
-	FInstancedStruct Observations;
-	CaptureAndCollect(Sensor, TestWorld, Observations);
-	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
-
+	// Sequential two-colour: baseline, red cube at centre (assert + destroy), green cube at +Y (assert).
 	const int32 Width = 64;
 	const int32 Height = 64;
-	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("SpatialLocalization"));
-
-	constexpr int32 GreenChannel = 1;
+	const FIntRect CenterRegion(Width * 3 / 8, Height * 3 / 8, Width * 5 / 8, Height * 5 / 8);
 	const FIntRect RightHalf(Width / 2, 0, Width, Height);
 	const FIntRect LeftHalf(0, 0, Width / 2, Height);
+	constexpr int32 RedChannel = 0;
+	constexpr int32 GreenChannel = 1;
 
-	// The +Y cube should localise to the right half of the image, leaving the left half dark.
-	AssertBoxPointRegionBrighter(
+	FInstancedStruct BaselineObservations;
+	CaptureAndCollect(Sensor, TestWorld, BaselineObservations);
+	const FBoxPoint& BaselineBoxPoint = BaselineObservations.Get<FBoxPoint>();
+	AssertBoxPointShape(*this, BaselineBoxPoint, 3, Height, Width, TEXT("SpatialLocalization baseline"));
+
+	UStaticMeshComponent* RedCube = SpawnColoredCube(
+		World,
+		FVector(0.0f, 0.0f, 0.0f),
+		FLinearColor(1.0f, 0.0f, 0.0f, 1.0f));
+	TestNotNull(TEXT("Red cube spawned"), RedCube);
+	SettleScene(TestWorld);
+
+	FInstancedStruct RedObservations;
+	CaptureAndCollect(Sensor, TestWorld, RedObservations);
+	const FBoxPoint& RedBoxPoint = RedObservations.Get<FBoxPoint>();
+
+	AssertBoxPointRegionChannelDeltaFromBaseline(
 		*this,
-		BoxPoint,
+		RedBoxPoint,
+		BaselineBoxPoint,
+		RedChannel,
+		CenterRegion,
+		CaptureSpatialMinChannelDelta,
+		TEXT("SpatialLocalization red centre vs baseline"));
+	AssertBoxPointRegionDominantChannel(
+		*this,
+		RedBoxPoint,
+		RedChannel,
+		CenterRegion,
+		TEXT("SpatialLocalization red dominates centre"));
+
+	DestroyColoredCube(RedCube, TestWorld);
+
+	UStaticMeshComponent* GreenCube = SpawnColoredCube(
+		World,
+		FVector(0.0f, 150.0f, 0.0f),
+		FLinearColor(0.0f, 1.0f, 0.0f, 1.0f));
+	TestNotNull(TEXT("Green cube spawned"), GreenCube);
+	SettleScene(TestWorld);
+
+	FInstancedStruct GreenObservations;
+	CaptureAndCollect(Sensor, TestWorld, GreenObservations);
+	const FBoxPoint& GreenBoxPoint = GreenObservations.Get<FBoxPoint>();
+
+	AssertBoxPointRegionChannelDeltaFromBaseline(
+		*this,
+		GreenBoxPoint,
+		BaselineBoxPoint,
 		GreenChannel,
 		RightHalf,
-		LeftHalf,
-		0.05f,
-		TEXT("SpatialLocalization +Y cube on right"));
+		CaptureSpatialMinChannelDelta,
+		TEXT("SpatialLocalization green right half vs baseline"));
+	AssertBoxPointRegionDominantChannel(
+		*this,
+		GreenBoxPoint,
+		GreenChannel,
+		RightHalf,
+		TEXT("SpatialLocalization green dominates right half"));
+
+	const float RightGreenDelta =
+		ComputeBoxPointRegionMean(GreenBoxPoint, GreenChannel, RightHalf)
+		- ComputeBoxPointRegionMean(BaselineBoxPoint, GreenChannel, RightHalf);
+	const float LeftGreenDelta =
+		ComputeBoxPointRegionMean(GreenBoxPoint, GreenChannel, LeftHalf)
+		- ComputeBoxPointRegionMean(BaselineBoxPoint, GreenChannel, LeftHalf);
+	TestTrue(
+		FString::Printf(
+			TEXT("SpatialLocalization right green delta %.3f should exceed left green delta %.3f by >= %.3f"),
+			RightGreenDelta,
+			LeftGreenDelta,
+			CaptureSpatialMinChannelDelta),
+		(RightGreenDelta - LeftGreenDelta) >= CaptureSpatialMinChannelDelta);
+
+	DestroyColoredCube(GreenCube, TestWorld);
 
 	return true;
 }

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
@@ -136,7 +136,7 @@ bool FCameraSensorIntegration_InvalidChannelsStripped_Test::RunTest(const FStrin
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ConvertBitmapToBoxPoint succeeds"),
-		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		CameraSensorUtils::ConvertBitmapToBoxPoint(
 			Bitmap,
 			8,
 			8,

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
@@ -134,12 +134,14 @@ bool FCameraSensorIntegration_InvalidChannelsStripped_Test::RunTest(const FStrin
 	Bitmap.Init(FColor(200, 100, 50, 255), 8 * 8);
 
 	FBoxPoint BoxPoint;
-	FCameraSensorUtils::ConvertBitmapToBoxPoint(
-		Bitmap,
-		8,
-		8,
-		Sensor->EnabledChannels & ~Sensor->GetInvalidChannels(),
-		BoxPoint);
+	TestTrue(
+		TEXT("ConvertBitmapToBoxPoint succeeds"),
+		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+			Bitmap,
+			8,
+			8,
+			Sensor->EnabledChannels & ~Sensor->GetInvalidChannels(),
+			BoxPoint));
 
 	TestEqual(TEXT("Only R collected for depth"), BoxPoint.Shape[0], 1);
 	TestEqual(TEXT("R value normalized"), BoxPoint.Values[0], 200.0f / 255.0f);

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorIntegrationTest.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#include "Test/Sensors/CameraSensorTestHelpers.h"
+
+#include "SensorInterface.h"
+#include "Sensors/CameraSensor.h"
+#include "Sensors/CameraSensorUtils.h"
+#include "Points/BoxPoint.h"
+#include "Spaces/BoxSpace.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+using namespace ScholaCameraSensorTest;
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorIntegration_IScholaSensorCollectFlow_Test,
+	"Schola.Sensors.CameraSensor.Integration.IScholaSensor.CollectFlow",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorIntegration_IScholaSensorCollectFlow_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR;
+	Sensor->EnabledChannels = 15;
+	Sensor->TextureTarget = CreateInitializedRenderTarget(Sensor, 8, 8);
+
+	if (!FillRenderTargetSolidColor(TestWorld.GetWorld(), Sensor->TextureTarget, FLinearColor(0.1f, 0.2f, 0.3f, 1.0f)))
+	{
+		return false;
+	}
+
+	TInstancedStruct<FPoint> Observations;
+	IScholaSensor::Execute_CollectObservations(Sensor, Observations);
+
+	TestTrue(TEXT("Interface dispatch returns BoxPoint"), Observations.GetScriptStruct() == FBoxPoint::StaticStruct());
+	TestTrue(TEXT("Interface dispatch populates values"), Observations.Get<FBoxPoint>().Values.Num() > 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorIntegration_ObsSpaceVsCollect_Test,
+	"Schola.Sensors.CameraSensor.Integration.ObsSpaceVsCollect",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorIntegration_ObsSpaceVsCollect_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->CaptureSource = ESceneCaptureSource::SCS_SceneColorSceneDepth;
+	Sensor->EnabledChannels = 15;
+	Sensor->TextureTarget = CreateInitializedRenderTarget(Sensor, 16, 16);
+	FillRenderTargetSolidColor(TestWorld.GetWorld(), Sensor->TextureTarget, FLinearColor(0.5f, 0.5f, 0.5f, 0.75f));
+
+	TInstancedStruct<FSpace> ObservationSpace;
+	IScholaSensor::Execute_GetObservationSpace(Sensor, ObservationSpace);
+	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
+
+	TInstancedStruct<FPoint> Observations;
+	IScholaSensor::Execute_CollectObservations(Sensor, Observations);
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+
+	TestEqual(TEXT("Shape matches between space and collect"), BoxPoint.Shape, Space.Shape);
+	TestEqual(TEXT("Value count matches space dimensions"), BoxPoint.Values.Num(), Space.Dimensions.Num());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorIntegration_EnabledChannelsRespected_Test,
+	"Schola.Sensors.CameraSensor.Integration.EnabledChannelsRespected",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorIntegration_EnabledChannelsRespected_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->CaptureSource = ESceneCaptureSource::SCS_SceneColorSceneDepth;
+	Sensor->EnabledChannels = static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::B);
+	Sensor->TextureTarget = CreateInitializedRenderTarget(Sensor, 4, 4);
+	FillRenderTargetSolidColor(TestWorld.GetWorld(), Sensor->TextureTarget, FLinearColor(1.0f, 0.0f, 1.0f, 1.0f));
+
+	FInstancedStruct Observations;
+	Sensor->CollectObservations_Implementation(Observations);
+	const FBoxPoint& BoxPoint = Observations.Get<FBoxPoint>();
+
+	TestEqual(TEXT("Only R and B enabled"), BoxPoint.Shape[0], 2);
+	TestEqual(TEXT("Value count for two channels"), BoxPoint.Values.Num(), 2 * 4 * 4);
+
+	const float ExpectedR = 1.0f;
+	const float ExpectedB = 1.0f;
+	TestTrue(TEXT("R channel preserved"), FMath::IsNearlyEqual(BoxPoint.Values[0], ExpectedR, 0.02f));
+	TestTrue(TEXT("B channel preserved"), FMath::IsNearlyEqual(BoxPoint.Values[4 * 4 + 0], ExpectedB, 0.02f));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorIntegration_InvalidChannelsStripped_Test,
+	"Schola.Sensors.CameraSensor.Integration.InvalidChannelsStripped",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorIntegration_InvalidChannelsStripped_Test::RunTest(const FString& Parameters)
+{
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->CaptureSource = ESceneCaptureSource::SCS_SceneDepth;
+	Sensor->EnabledChannels = 15;
+	Sensor->TextureTarget = NewObject<UTextureRenderTarget2D>(Sensor);
+	Sensor->TextureTarget->RenderTargetFormat = ETextureRenderTargetFormat::RTF_RGBA8;
+	Sensor->TextureTarget->SizeX = 8;
+	Sensor->TextureTarget->SizeY = 8;
+
+	TestEqual(TEXT("SceneDepth exposes one channel"), Sensor->GetNumChannels(), 1);
+
+	TArray<FColor> Bitmap;
+	Bitmap.Init(FColor(200, 100, 50, 255), 8 * 8);
+
+	FBoxPoint BoxPoint;
+	FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		Bitmap,
+		8,
+		8,
+		Sensor->EnabledChannels & ~Sensor->GetInvalidChannels(),
+		BoxPoint);
+
+	TestEqual(TEXT("Only R collected for depth"), BoxPoint.Shape[0], 1);
+	TestEqual(TEXT("R value normalized"), BoxPoint.Values[0], 200.0f / 255.0f);
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
@@ -1,0 +1,326 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#include "Test/Sensors/CameraSensorTestHelpers.h"
+
+#include "Sensors/CameraSensor.h"
+#include "Sensors/CameraSensorUtils.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Points/BoxPoint.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+using namespace ScholaCameraSensorTest;
+
+static constexpr float GColorTolerance = 0.02f;
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_SolidRedBase_Test,
+	"Schola.Sensors.CameraSensor.Readback.SolidRed.Base",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorReadback_SolidRedBase_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	UWorld* World = TestWorld.GetWorld();
+	constexpr int32 Width = 8;
+	constexpr int32 Height = 8;
+
+	UTextureRenderTarget2D* RenderTarget = CreateInitializedRenderTarget(GetTransientPackage(), Width, Height);
+	TestTrue(TEXT("Render target created"), RenderTarget != nullptr);
+	if (!RenderTarget || !FillRenderTargetSolidColor(World, RenderTarget, FLinearColor(1.0f, 0.0f, 0.0f, 1.0f)))
+	{
+		return false;
+	}
+
+	const uint8 EnabledChannels =
+		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B);
+
+	FBoxPoint BoxPoint;
+	TestTrue(
+		TEXT("ReadRenderTargetToBoxPoint succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+
+	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("SolidRed.Base"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 0, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.Base R"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 1, Height / 2, Width / 2, Width, Height, 0.0f, GColorTolerance, TEXT("SolidRed.Base G"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 2, Height / 2, Width / 2, Width, Height, 0.0f, GColorTolerance, TEXT("SolidRed.Base B"));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_SolidRedWithAlpha_Test,
+	"Schola.Sensors.CameraSensor.Readback.SolidRed.WithAlpha",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorReadback_SolidRedWithAlpha_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	constexpr int32 Width = 8;
+	constexpr int32 Height = 8;
+
+	UTextureRenderTarget2D* RenderTarget = CreateInitializedRenderTarget(GetTransientPackage(), Width, Height);
+	if (!RenderTarget || !FillRenderTargetSolidColor(TestWorld.GetWorld(), RenderTarget, FLinearColor(1.0f, 0.0f, 0.0f, 1.0f)))
+	{
+		return false;
+	}
+
+	const uint8 EnabledChannels = 15;
+
+	FBoxPoint BoxPoint;
+	TestTrue(
+		TEXT("ReadRenderTargetToBoxPoint succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+
+	AssertBoxPointShape(*this, BoxPoint, 4, Height, Width, TEXT("SolidRed.WithAlpha"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 3, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.WithAlpha A"));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_ViaCollectObservations_Test,
+	"Schola.Sensors.CameraSensor.Readback.ViaCollectObservations",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorReadback_ViaCollectObservations_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	constexpr int32 Width = 8;
+	constexpr int32 Height = 8;
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR;
+	Sensor->EnabledChannels = 15;
+	Sensor->TextureTarget = CreateInitializedRenderTarget(Sensor, Width, Height);
+
+	if (!FillRenderTargetSolidColor(TestWorld.GetWorld(), Sensor->TextureTarget, FLinearColor(0.0f, 1.0f, 0.0f, 1.0f)))
+	{
+		return false;
+	}
+
+	const uint8 EnabledValidChannels = GetEnabledValidChannels(Sensor);
+
+	FBoxPoint DirectBoxPoint;
+	TestTrue(
+		TEXT("Direct readback succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(Sensor->TextureTarget, EnabledValidChannels, DirectBoxPoint));
+
+	FInstancedStruct Observations;
+	Sensor->CollectObservations_Implementation(Observations);
+	TestTrue(TEXT("CollectObservations returns BoxPoint"), Observations.GetScriptStruct() == FBoxPoint::StaticStruct());
+
+	const FBoxPoint& CollectedBoxPoint = Observations.Get<FBoxPoint>();
+	TestEqual(TEXT("Collected shape matches direct readback"), CollectedBoxPoint.Shape, DirectBoxPoint.Shape);
+	TestEqual(TEXT("Collected values match direct readback"), CollectedBoxPoint.Values, DirectBoxPoint.Values);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_ChannelMaskROnly_Test,
+	"Schola.Sensors.CameraSensor.Readback.ChannelMask.R_Only",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorReadback_ChannelMaskROnly_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	constexpr int32 Width = 4;
+	constexpr int32 Height = 3;
+
+	TArray<FColor> Bitmap;
+	BuildKnownColorBitmap(Width, Height, Bitmap);
+
+	UTextureRenderTarget2D* RenderTarget = CreateInitializedRenderTarget(GetTransientPackage(), Width, Height);
+	if (!FillRenderTargetFromBitmap(TestWorld.GetWorld(), RenderTarget, Bitmap, Width, Height))
+	{
+		return false;
+	}
+
+	const uint8 EnabledChannels = static_cast<uint8>(EChannels::R);
+
+	FBoxPoint BoxPoint;
+	TestTrue(
+		TEXT("ReadRenderTargetToBoxPoint succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+
+	AssertBoxPointShape(*this, BoxPoint, 1, Height, Width, TEXT("ChannelMask.R_Only"));
+
+	for (int32 H = 0; H < Height; ++H)
+	{
+		for (int32 W = 0; W < Width; ++W)
+		{
+			const int32 PixelIndex = H * Width + W;
+			const float ExpectedR = static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
+			TestEqual(
+				FString::Printf(TEXT("R channel at (%d, %d)"), W, H),
+				BoxPoint.Values[PixelIndex],
+				ExpectedR);
+		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_ChannelMaskRGOnly_Test,
+	"Schola.Sensors.CameraSensor.Readback.ChannelMask.RG_Only",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+
+bool FCameraSensorReadback_ChannelMaskRGOnly_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	constexpr int32 Width = 4;
+	constexpr int32 Height = 3;
+
+	TArray<FColor> Bitmap;
+	BuildKnownColorBitmap(Width, Height, Bitmap);
+
+	UTextureRenderTarget2D* RenderTarget = CreateInitializedRenderTarget(
+		GetTransientPackage(),
+		Width,
+		Height,
+		ETextureRenderTargetFormat::RTF_RG8);
+
+	if (!FillRenderTargetFromBitmap(TestWorld.GetWorld(), RenderTarget, Bitmap, Width, Height))
+	{
+		return false;
+	}
+
+	const uint8 EnabledChannels = static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G);
+
+	FBoxPoint BoxPoint;
+	TestTrue(
+		TEXT("ReadRenderTargetToBoxPoint succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+
+	AssertBoxPointShape(*this, BoxPoint, 2, Height, Width, TEXT("ChannelMask.RG_Only"));
+
+	const int32 ChannelStride = Width * Height;
+	for (int32 H = 0; H < Height; ++H)
+	{
+		for (int32 W = 0; W < Width; ++W)
+		{
+			const int32 PixelIndex = H * Width + W;
+			const float ExpectedR = static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
+			const float ExpectedG = static_cast<float>(Bitmap[PixelIndex].G) / 255.0f;
+			TestEqual(
+				FString::Printf(TEXT("R channel at (%d, %d)"), W, H),
+				BoxPoint.Values[0 * ChannelStride + PixelIndex],
+				ExpectedR);
+			TestEqual(
+				FString::Printf(TEXT("G channel at (%d, %d)"), W, H),
+				BoxPoint.Values[1 * ChannelStride + PixelIndex],
+				ExpectedG);
+		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_NonSquare_Test,
+	"Schola.Sensors.CameraSensor.Readback.NonSquare",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorReadback_NonSquare_Test::RunTest(const FString& Parameters)
+{
+	FScholaCameraSensorTestWorld TestWorld;
+	if (!TestWorld.Setup(this))
+	{
+		return false;
+	}
+
+	constexpr int32 Width = 320;
+	constexpr int32 Height = 240;
+
+	UTextureRenderTarget2D* RenderTarget = CreateInitializedRenderTarget(GetTransientPackage(), Width, Height);
+	if (!FillRenderTargetSolidColor(TestWorld.GetWorld(), RenderTarget, FLinearColor(0.2f, 0.4f, 0.6f, 1.0f)))
+	{
+		return false;
+	}
+
+	const uint8 EnabledChannels =
+		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B);
+
+	FBoxPoint BoxPoint;
+	TestTrue(
+		TEXT("ReadRenderTargetToBoxPoint succeeds"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+
+	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("NonSquare"));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_NullTarget_Test,
+	"Schola.Sensors.CameraSensor.Readback.NullTarget",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorReadback_NullTarget_Test::RunTest(const FString& Parameters)
+{
+	AddExpectedError(TEXT("RenderTarget not found. Not collecting Observations."), EAutomationExpectedErrorFlags::Contains, 1);
+	AddExpectedError(TEXT("TextureTarget is null."), EAutomationExpectedErrorFlags::Contains, 1);
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>(GetTransientPackage());
+	Sensor->TextureTarget = nullptr;
+
+	FInstancedStruct Observations;
+	Sensor->CollectObservations_Implementation(Observations);
+
+	FBoxPoint BoxPoint;
+	TestFalse(
+		TEXT("ReadRenderTargetToBoxPoint fails for null target"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(nullptr, 15, BoxPoint));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorReadback_UninitializedResource_Test,
+	"Schola.Sensors.CameraSensor.Readback.UninitializedResource",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+bool FCameraSensorReadback_UninitializedResource_Test::RunTest(const FString& Parameters)
+{
+	AddExpectedError(TEXT("Render target resource is null."), EAutomationExpectedErrorFlags::Contains, 1);
+
+	UTextureRenderTarget2D* RenderTarget = NewObject<UTextureRenderTarget2D>(GetTransientPackage());
+	RenderTarget->RenderTargetFormat = ETextureRenderTargetFormat::RTF_RGBA8;
+	RenderTarget->SizeX = 8;
+	RenderTarget->SizeY = 8;
+
+	FBoxPoint BoxPoint;
+	TestFalse(
+		TEXT("ReadRenderTargetToBoxPoint fails without initialized resource"),
+		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, 15, BoxPoint));
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
@@ -45,7 +45,7 @@ bool FCameraSensorReadback_SolidRedBase_Test::RunTest(const FString& Parameters)
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ReadRenderTargetToBoxPoint succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("SolidRed.Base"));
 	AssertBoxPointChannelNear(*this, BoxPoint, 0, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.Base R"));
@@ -82,7 +82,7 @@ bool FCameraSensorReadback_SolidRedWithAlpha_Test::RunTest(const FString& Parame
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ReadRenderTargetToBoxPoint succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 4, Height, Width, TEXT("SolidRed.WithAlpha"));
 	AssertBoxPointChannelNear(*this, BoxPoint, 3, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.WithAlpha A"));
@@ -121,7 +121,7 @@ bool FCameraSensorReadback_ViaCollectObservations_Test::RunTest(const FString& P
 	FBoxPoint DirectBoxPoint;
 	TestTrue(
 		TEXT("Direct readback succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(Sensor->TextureTarget, EnabledValidChannels, DirectBoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(Sensor->TextureTarget, EnabledValidChannels, DirectBoxPoint));
 
 	FInstancedStruct Observations;
 	Sensor->CollectObservations_Implementation(Observations);
@@ -164,7 +164,7 @@ bool FCameraSensorReadback_ChannelMaskROnly_Test::RunTest(const FString& Paramet
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ReadRenderTargetToBoxPoint succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 1, Height, Width, TEXT("ChannelMask.R_Only"));
 
@@ -219,7 +219,7 @@ bool FCameraSensorReadback_ChannelMaskRGOnly_Test::RunTest(const FString& Parame
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ReadRenderTargetToBoxPoint succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 2, Height, Width, TEXT("ChannelMask.RG_Only"));
 
@@ -272,7 +272,7 @@ bool FCameraSensorReadback_NonSquare_Test::RunTest(const FString& Parameters)
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ReadRenderTargetToBoxPoint succeeds"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("NonSquare"));
 
@@ -297,7 +297,7 @@ bool FCameraSensorReadback_NullTarget_Test::RunTest(const FString& Parameters)
 	FBoxPoint BoxPoint;
 	TestFalse(
 		TEXT("ReadRenderTargetToBoxPoint fails for null target"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(nullptr, 15, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(nullptr, 15, BoxPoint));
 
 	return true;
 }
@@ -318,7 +318,7 @@ bool FCameraSensorReadback_UninitializedResource_Test::RunTest(const FString& Pa
 	FBoxPoint BoxPoint;
 	TestFalse(
 		TEXT("ReadRenderTargetToBoxPoint fails without initialized resource"),
-		FCameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, 15, BoxPoint));
+		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, 15, BoxPoint));
 
 	return true;
 }

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorRenderTargetTest.cpp
@@ -48,9 +48,9 @@ bool FCameraSensorReadback_SolidRedBase_Test::RunTest(const FString& Parameters)
 		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 3, Height, Width, TEXT("SolidRed.Base"));
-	AssertBoxPointChannelNear(*this, BoxPoint, 0, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.Base R"));
-	AssertBoxPointChannelNear(*this, BoxPoint, 1, Height / 2, Width / 2, Width, Height, 0.0f, GColorTolerance, TEXT("SolidRed.Base G"));
-	AssertBoxPointChannelNear(*this, BoxPoint, 2, Height / 2, Width / 2, Width, Height, 0.0f, GColorTolerance, TEXT("SolidRed.Base B"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 0, Height / 2, Width / 2, 1.0f, GColorTolerance, TEXT("SolidRed.Base R"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 1, Height / 2, Width / 2, 0.0f, GColorTolerance, TEXT("SolidRed.Base G"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 2, Height / 2, Width / 2, 0.0f, GColorTolerance, TEXT("SolidRed.Base B"));
 
 	return true;
 }
@@ -85,7 +85,7 @@ bool FCameraSensorReadback_SolidRedWithAlpha_Test::RunTest(const FString& Parame
 		CameraSensorUtils::ReadRenderTargetToBoxPoint(RenderTarget, EnabledChannels, BoxPoint));
 
 	AssertBoxPointShape(*this, BoxPoint, 4, Height, Width, TEXT("SolidRed.WithAlpha"));
-	AssertBoxPointChannelNear(*this, BoxPoint, 3, Height / 2, Width / 2, Width, Height, 1.0f, GColorTolerance, TEXT("SolidRed.WithAlpha A"));
+	AssertBoxPointChannelNear(*this, BoxPoint, 3, Height / 2, Width / 2, 1.0f, GColorTolerance, TEXT("SolidRed.WithAlpha A"));
 
 	return true;
 }

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
@@ -110,7 +110,7 @@ namespace ScholaCameraSensorTest
 		}
 
 		UKismetRenderingLibrary::ClearRenderTarget2D(World, RenderTarget, Color);
-		FlushRendering();
+		FlushRenderingCommands();
 		return true;
 	}
 
@@ -155,27 +155,20 @@ namespace ScholaCameraSensorTest
 				FVector2D::ZeroVector);
 		}
 		UKismetRenderingLibrary::EndDrawCanvasToRenderTarget(World, Context);
-		FlushRendering();
+		FlushRenderingCommands();
 
 		SourceTexture->RemoveFromRoot();
 		return true;
-	}
-
-	void FlushRendering()
-	{
-		FlushRenderingCommands();
 	}
 
 	float GetBoxPointChannelValue(
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
 		int32 PixelY,
-		int32 PixelX,
-		int32 Width,
-		int32 Height)
+		int32 PixelX)
 	{
-		const int32 ChannelStride = Width * Height;
-		const int32 PixelIndex = PixelY * Width + PixelX;
+		const int32 ChannelStride = BoxPoint.Shape[1] * BoxPoint.Shape[2];
+		const int32 PixelIndex = PixelY * BoxPoint.Shape[2] + PixelX;
 		return BoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex];
 	}
 
@@ -205,13 +198,11 @@ namespace ScholaCameraSensorTest
 		int32 ChannelIndex,
 		int32 PixelY,
 		int32 PixelX,
-		int32 Width,
-		int32 Height,
 		float ExpectedValue,
 		float Tolerance,
 		const TCHAR* Context)
 	{
-		const float Actual = GetBoxPointChannelValue(BoxPoint, ChannelIndex, PixelY, PixelX, Width, Height);
+		const float Actual = GetBoxPointChannelValue(BoxPoint, ChannelIndex, PixelY, PixelX);
 		return Test.TestTrue(
 			FString::Printf(
 				TEXT("%s: channel %d at (%d,%d) expected ~%.3f got %.3f"),
@@ -227,10 +218,10 @@ namespace ScholaCameraSensorTest
 	float ComputeBoxPointRegionMean(
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
-		const FIntRect& Region,
-		int32 Width,
-		int32 Height)
+		const FIntRect& Region)
 	{
+		const int32 Width = BoxPoint.Shape[2];
+		const int32 Height = BoxPoint.Shape[1];
 		const int32 StartX = FMath::Clamp(Region.Min.X, 0, Width);
 		const int32 EndX = FMath::Clamp(Region.Max.X, 0, Width);
 		const int32 StartY = FMath::Clamp(Region.Min.Y, 0, Height);
@@ -242,67 +233,11 @@ namespace ScholaCameraSensorTest
 		{
 			for (int32 X = StartX; X < EndX; ++X)
 			{
-				Sum += GetBoxPointChannelValue(BoxPoint, ChannelIndex, Y, X, Width, Height);
+				Sum += GetBoxPointChannelValue(BoxPoint, ChannelIndex, Y, X);
 				++Count;
 			}
 		}
 		return Count > 0 ? Sum / static_cast<float>(Count) : 0.0f;
-	}
-
-	static float ComputeRegionMean(
-		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
-		int32 Width,
-		int32 Height)
-	{
-		return ComputeBoxPointRegionMean(
-			BoxPoint,
-			ChannelIndex,
-			FIntRect(StartX, StartY, EndX, EndY),
-			Width,
-			Height);
-	}
-
-	bool AssertBoxPointRegionMeanAbove(
-		FAutomationTestBase& Test,
-		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
-		int32 Width,
-		int32 Height,
-		float MinMean,
-		const TCHAR* Context)
-	{
-		const float Mean = ComputeRegionMean(BoxPoint, ChannelIndex, StartY, EndY, StartX, EndX, Width, Height);
-		return Test.TestTrue(
-			FString::Printf(TEXT("%s: region mean %.3f should be above %.3f"), Context, Mean, MinMean),
-			Mean > MinMean);
-	}
-
-	bool AssertBoxPointRegionMeanBelow(
-		FAutomationTestBase& Test,
-		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
-		int32 Width,
-		int32 Height,
-		float MaxMean,
-		const TCHAR* Context)
-	{
-		const float Mean = ComputeRegionMean(BoxPoint, ChannelIndex, StartY, EndY, StartX, EndX, Width, Height);
-		return Test.TestTrue(
-			FString::Printf(TEXT("%s: region mean %.3f should be below %.3f"), Context, Mean, MaxMean),
-			Mean < MaxMean);
 	}
 
 	bool AssertBoxPointRegionBrighter(
@@ -311,13 +246,11 @@ namespace ScholaCameraSensorTest
 		int32 ChannelIndex,
 		const FIntRect& BrightRegion,
 		const FIntRect& DimRegion,
-		int32 Width,
-		int32 Height,
 		float MinDelta,
 		const TCHAR* Context)
 	{
-		const float BrightMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, BrightRegion, Width, Height);
-		const float DimMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, DimRegion, Width, Height);
+		const float BrightMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, BrightRegion);
+		const float DimMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, DimRegion);
 		return Test.TestTrue(
 			FString::Printf(
 				TEXT("%s: channel %d bright-region mean %.3f should exceed dim-region mean %.3f by >= %.3f"),
@@ -448,7 +381,7 @@ namespace ScholaCameraSensorTest
 		{
 			TestWorld.Tick(0.016f);
 		}
-		FlushRendering();
+		FlushRenderingCommands();
 		Sensor->CollectObservations_Implementation(OutObservations);
 	}
 

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
@@ -1,0 +1,419 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Test/Sensors/CameraSensorTestHelpers.h"
+
+#include "Sensors/CameraSensorUtils.h"
+#include "Components/SceneComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/Canvas.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/Texture2D.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Kismet/KismetRenderingLibrary.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "RHICommandList.h"
+
+bool FScholaCameraSensorTestWorld::Setup(FAutomationTestBase* InTest)
+{
+	Test = InTest;
+	if (!Wrapper.CreateTestWorld(EWorldType::Game))
+	{
+		Test->AddError(TEXT("Failed to create camera sensor test world"));
+		return false;
+	}
+	Phase = EPhase::Created;
+
+	if (!Wrapper.GetTestWorld())
+	{
+		Test->AddError(TEXT("Failed to get camera sensor test world"));
+		Wrapper.DestroyTestWorld(true);
+		Phase = EPhase::None;
+		return false;
+	}
+
+	if (!Wrapper.BeginPlayInTestWorld())
+	{
+		Test->AddError(TEXT("Failed to begin play in camera sensor test world"));
+		Wrapper.DestroyTestWorld(true);
+		Phase = EPhase::None;
+		return false;
+	}
+
+	Phase = EPhase::Playing;
+	for (int32 i = 0; i < 3; ++i)
+	{
+		Wrapper.TickTestWorld(0.016f);
+	}
+	return true;
+}
+
+void FScholaCameraSensorTestWorld::Tick(float DeltaSeconds)
+{
+	if (Phase == EPhase::Playing)
+	{
+		Wrapper.TickTestWorld(DeltaSeconds);
+	}
+}
+
+FScholaCameraSensorTestWorld::~FScholaCameraSensorTestWorld()
+{
+	if (Phase == EPhase::Playing)
+	{
+		Wrapper.EndPlayInTestWorld();
+	}
+	if (Phase == EPhase::Playing || Phase == EPhase::Created)
+	{
+		Wrapper.DestroyTestWorld(true);
+	}
+}
+
+namespace ScholaCameraSensorTest
+{
+	void BuildKnownColorBitmap(int32 Width, int32 Height, TArray<FColor>& OutBitmap)
+	{
+		const int32 PixelCount = Width * Height;
+		OutBitmap.SetNum(PixelCount);
+
+		for (int32 H = 0; H < Height; ++H)
+		{
+			for (int32 W = 0; W < Width; ++W)
+			{
+				const int32 PixelIndex = H * Width + W;
+				OutBitmap[PixelIndex] = FColor(
+					static_cast<uint8>(W * Height + H),
+					static_cast<uint8>(H * Width + W),
+					static_cast<uint8>((W + H) % 256),
+					255);
+			}
+		}
+	}
+
+	UTextureRenderTarget2D* CreateInitializedRenderTarget(
+		UObject* Outer,
+		int32 Width,
+		int32 Height,
+		ETextureRenderTargetFormat Format)
+	{
+		UTextureRenderTarget2D* RenderTarget = NewObject<UTextureRenderTarget2D>(Outer);
+		RenderTarget->RenderTargetFormat = Format;
+		RenderTarget->InitAutoFormat(Width, Height);
+		RenderTarget->UpdateResourceImmediate(true);
+		return RenderTarget;
+	}
+
+	bool FillRenderTargetSolidColor(UWorld* World, UTextureRenderTarget2D* RenderTarget, const FLinearColor& Color)
+	{
+		if (!World || !RenderTarget)
+		{
+			return false;
+		}
+
+		UKismetRenderingLibrary::ClearRenderTarget2D(World, RenderTarget, Color);
+		FlushRendering();
+		return true;
+	}
+
+	bool FillRenderTargetFromBitmap(
+		UWorld* World,
+		UTextureRenderTarget2D* RenderTarget,
+		const TArray<FColor>& Bitmap,
+		int32 Width,
+		int32 Height)
+	{
+		if (!World || !RenderTarget || Bitmap.Num() != Width * Height)
+		{
+			return false;
+		}
+
+		UTexture2D* SourceTexture = UTexture2D::CreateTransient(Width, Height, PF_B8G8R8A8);
+		if (!SourceTexture)
+		{
+			return false;
+		}
+
+		SourceTexture->CompressionSettings = TC_EditorIcon;
+		SourceTexture->SRGB = false;
+		SourceTexture->AddToRoot();
+
+		FTexture2DMipMap& Mip = SourceTexture->GetPlatformData()->Mips[0];
+		void* TextureData = Mip.BulkData.Lock(LOCK_READ_WRITE);
+		FMemory::Memcpy(TextureData, Bitmap.GetData(), Bitmap.Num() * sizeof(FColor));
+		Mip.BulkData.Unlock();
+		SourceTexture->UpdateResource();
+
+		UCanvas* Canvas = nullptr;
+		FVector2D CanvasSize;
+		FDrawToRenderTargetContext Context;
+		UKismetRenderingLibrary::BeginDrawCanvasToRenderTarget(World, RenderTarget, Canvas, CanvasSize, Context);
+		if (Canvas)
+		{
+			Canvas->K2_DrawTexture(
+				SourceTexture,
+				FVector2D::ZeroVector,
+				CanvasSize,
+				FVector2D::ZeroVector);
+		}
+		UKismetRenderingLibrary::EndDrawCanvasToRenderTarget(World, Context);
+		FlushRendering();
+
+		SourceTexture->RemoveFromRoot();
+		return true;
+	}
+
+	void FlushRendering()
+	{
+		FlushRenderingCommands();
+	}
+
+	float GetBoxPointChannelValue(
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 PixelY,
+		int32 PixelX,
+		int32 Width,
+		int32 Height)
+	{
+		const int32 ChannelStride = Width * Height;
+		const int32 PixelIndex = PixelY * Width + PixelX;
+		return BoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex];
+	}
+
+	bool AssertBoxPointShape(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ExpectedChannels,
+		int32 ExpectedHeight,
+		int32 ExpectedWidth,
+		const TCHAR* Context)
+	{
+		bool bOk = true;
+		bOk &= Test.TestEqual(FString::Printf(TEXT("%s: shape rank"), Context), BoxPoint.Shape.Num(), 3);
+		bOk &= Test.TestEqual(FString::Printf(TEXT("%s: channels"), Context), BoxPoint.Shape[0], ExpectedChannels);
+		bOk &= Test.TestEqual(FString::Printf(TEXT("%s: height"), Context), BoxPoint.Shape[1], ExpectedHeight);
+		bOk &= Test.TestEqual(FString::Printf(TEXT("%s: width"), Context), BoxPoint.Shape[2], ExpectedWidth);
+		bOk &= Test.TestEqual(
+			FString::Printf(TEXT("%s: value count"), Context),
+			BoxPoint.Values.Num(),
+			ExpectedChannels * ExpectedHeight * ExpectedWidth);
+		return bOk;
+	}
+
+	bool AssertBoxPointChannelNear(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 PixelY,
+		int32 PixelX,
+		int32 Width,
+		int32 Height,
+		float ExpectedValue,
+		float Tolerance,
+		const TCHAR* Context)
+	{
+		const float Actual = GetBoxPointChannelValue(BoxPoint, ChannelIndex, PixelY, PixelX, Width, Height);
+		return Test.TestTrue(
+			FString::Printf(
+				TEXT("%s: channel %d at (%d,%d) expected ~%.3f got %.3f"),
+				Context,
+				ChannelIndex,
+				PixelX,
+				PixelY,
+				ExpectedValue,
+				Actual),
+			FMath::IsNearlyEqual(Actual, ExpectedValue, Tolerance));
+	}
+
+	static float ComputeRegionMean(
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height)
+	{
+		float Sum = 0.0f;
+		int32 Count = 0;
+		for (int32 Y = StartY; Y < EndY; ++Y)
+		{
+			for (int32 X = StartX; X < EndX; ++X)
+			{
+				Sum += GetBoxPointChannelValue(BoxPoint, ChannelIndex, Y, X, Width, Height);
+				++Count;
+			}
+		}
+		return Count > 0 ? Sum / static_cast<float>(Count) : 0.0f;
+	}
+
+	bool AssertBoxPointRegionMeanAbove(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height,
+		float MinMean,
+		const TCHAR* Context)
+	{
+		const float Mean = ComputeRegionMean(BoxPoint, ChannelIndex, StartY, EndY, StartX, EndX, Width, Height);
+		return Test.TestTrue(
+			FString::Printf(TEXT("%s: region mean %.3f should be above %.3f"), Context, Mean, MinMean),
+			Mean > MinMean);
+	}
+
+	bool AssertBoxPointRegionMeanBelow(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height,
+		float MaxMean,
+		const TCHAR* Context)
+	{
+		const float Mean = ComputeRegionMean(BoxPoint, ChannelIndex, StartY, EndY, StartX, EndX, Width, Height);
+		return Test.TestTrue(
+			FString::Printf(TEXT("%s: region mean %.3f should be below %.3f"), Context, Mean, MaxMean),
+			Mean < MaxMean);
+	}
+
+	UCameraSensor* SpawnCameraSensor(
+		UWorld* World,
+		const FVector& Location,
+		const FRotator& Rotation,
+		int32 RenderTargetWidth,
+		int32 RenderTargetHeight,
+		ESceneCaptureSource CaptureSource,
+		uint8 EnabledChannels,
+		bool bCallInitSensor,
+		bool bCreateRenderTarget)
+	{
+		if (!World)
+		{
+			return nullptr;
+		}
+
+		FActorSpawnParameters SpawnParams;
+		SpawnParams.ObjectFlags = RF_Transient;
+		AActor* Owner = World->SpawnActor<AActor>(AActor::StaticClass(), Location, Rotation, SpawnParams);
+		if (!Owner)
+		{
+			return nullptr;
+		}
+
+		USceneComponent* Root = NewObject<USceneComponent>(Owner, TEXT("Root"));
+		Root->SetMobility(EComponentMobility::Movable);
+		Owner->SetRootComponent(Root);
+		Root->RegisterComponent();
+
+		UCameraSensor* Sensor = NewObject<UCameraSensor>(Owner, TEXT("CameraSensor"));
+		Sensor->SetupAttachment(Root);
+		Sensor->SetRelativeLocation(FVector::ZeroVector);
+		Sensor->RegisterComponent();
+
+		Sensor->CaptureSource = CaptureSource;
+		Sensor->EnabledChannels = EnabledChannels;
+		Sensor->bCaptureEveryFrame = false;
+
+		if (bCreateRenderTarget)
+		{
+			Sensor->TextureTarget = CreateInitializedRenderTarget(
+				Sensor,
+				RenderTargetWidth,
+				RenderTargetHeight,
+				ETextureRenderTargetFormat::RTF_RGBA8);
+			Sensor->TextureTarget->bGPUSharedFlag = true;
+		}
+
+		if (bCallInitSensor)
+		{
+			Sensor->InitSensor_Implementation();
+		}
+
+		return Sensor;
+	}
+
+	UStaticMeshComponent* SpawnColoredCube(
+		UWorld* World,
+		const FVector& Location,
+		const FLinearColor& Color,
+		const FVector& Scale,
+		UStaticMesh* CubeMesh)
+	{
+		if (!World)
+		{
+			return nullptr;
+		}
+
+		if (!CubeMesh)
+		{
+			CubeMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cube.Cube"));
+		}
+		if (!CubeMesh)
+		{
+			return nullptr;
+		}
+
+		UMaterialInterface* BaseMaterial = LoadObject<UMaterialInterface>(
+			nullptr,
+			TEXT("/Engine/BasicShapes/BasicShapeMaterial.BasicShapeMaterial"));
+		if (!BaseMaterial)
+		{
+			return nullptr;
+		}
+
+		FActorSpawnParameters SpawnParams;
+		SpawnParams.ObjectFlags = RF_Transient;
+		AActor* CubeActor = World->SpawnActor<AActor>(AActor::StaticClass(), Location, FRotator::ZeroRotator, SpawnParams);
+		if (!CubeActor)
+		{
+			return nullptr;
+		}
+
+		UStaticMeshComponent* MeshComponent = NewObject<UStaticMeshComponent>(CubeActor, TEXT("CubeMesh"));
+		MeshComponent->SetStaticMesh(CubeMesh);
+		MeshComponent->SetMobility(EComponentMobility::Movable);
+		MeshComponent->SetWorldScale3D(Scale);
+		CubeActor->SetRootComponent(MeshComponent);
+		MeshComponent->RegisterComponent();
+
+		UMaterialInstanceDynamic* DynamicMaterial = UMaterialInstanceDynamic::Create(BaseMaterial, MeshComponent);
+		DynamicMaterial->SetVectorParameterValue(TEXT("Color"), Color);
+		MeshComponent->SetMaterial(0, DynamicMaterial);
+
+		return MeshComponent;
+	}
+
+	void CaptureAndCollect(UCameraSensor* Sensor, FScholaCameraSensorTestWorld& TestWorld, FInstancedStruct& OutObservations)
+	{
+		if (!Sensor)
+		{
+			return;
+		}
+
+		Sensor->CaptureScene();
+		for (int32 i = 0; i < 3; ++i)
+		{
+			TestWorld.Tick(0.016f);
+		}
+		FlushRendering();
+		Sensor->CollectObservations_Implementation(OutObservations);
+	}
+
+	uint8 GetEnabledValidChannels(const UCameraSensor* Sensor)
+	{
+		if (!Sensor)
+		{
+			return 0;
+		}
+		return Sensor->EnabledChannels & ~Sensor->GetInvalidChannels();
+	}
+}

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
@@ -224,16 +224,18 @@ namespace ScholaCameraSensorTest
 			FMath::IsNearlyEqual(Actual, ExpectedValue, Tolerance));
 	}
 
-	static float ComputeRegionMean(
+	float ComputeBoxPointRegionMean(
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
+		const FIntRect& Region,
 		int32 Width,
 		int32 Height)
 	{
+		const int32 StartX = FMath::Clamp(Region.Min.X, 0, Width);
+		const int32 EndX = FMath::Clamp(Region.Max.X, 0, Width);
+		const int32 StartY = FMath::Clamp(Region.Min.Y, 0, Height);
+		const int32 EndY = FMath::Clamp(Region.Max.Y, 0, Height);
+
 		float Sum = 0.0f;
 		int32 Count = 0;
 		for (int32 Y = StartY; Y < EndY; ++Y)
@@ -245,6 +247,24 @@ namespace ScholaCameraSensorTest
 			}
 		}
 		return Count > 0 ? Sum / static_cast<float>(Count) : 0.0f;
+	}
+
+	static float ComputeRegionMean(
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height)
+	{
+		return ComputeBoxPointRegionMean(
+			BoxPoint,
+			ChannelIndex,
+			FIntRect(StartX, StartY, EndX, EndY),
+			Width,
+			Height);
 	}
 
 	bool AssertBoxPointRegionMeanAbove(
@@ -283,6 +303,30 @@ namespace ScholaCameraSensorTest
 		return Test.TestTrue(
 			FString::Printf(TEXT("%s: region mean %.3f should be below %.3f"), Context, Mean, MaxMean),
 			Mean < MaxMean);
+	}
+
+	bool AssertBoxPointRegionBrighter(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		const FIntRect& BrightRegion,
+		const FIntRect& DimRegion,
+		int32 Width,
+		int32 Height,
+		float MinDelta,
+		const TCHAR* Context)
+	{
+		const float BrightMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, BrightRegion, Width, Height);
+		const float DimMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, DimRegion, Width, Height);
+		return Test.TestTrue(
+			FString::Printf(
+				TEXT("%s: channel %d bright-region mean %.3f should exceed dim-region mean %.3f by >= %.3f"),
+				Context,
+				ChannelIndex,
+				BrightMean,
+				DimMean,
+				MinDelta),
+			(BrightMean - DimMean) >= MinDelta);
 	}
 
 	UCameraSensor* SpawnCameraSensor(

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.cpp
@@ -239,27 +239,59 @@ namespace ScholaCameraSensorTest
 		}
 		return Count > 0 ? Sum / static_cast<float>(Count) : 0.0f;
 	}
-
-	bool AssertBoxPointRegionBrighter(
+	
+	bool AssertBoxPointRegionChannelDeltaFromBaseline(
 		FAutomationTestBase& Test,
-		const FBoxPoint& BoxPoint,
+		const FBoxPoint& Observed,
+		const FBoxPoint& Baseline,
 		int32 ChannelIndex,
-		const FIntRect& BrightRegion,
-		const FIntRect& DimRegion,
+		const FIntRect& Region,
 		float MinDelta,
 		const TCHAR* Context)
 	{
-		const float BrightMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, BrightRegion);
-		const float DimMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, DimRegion);
+		const float ObservedMean = ComputeBoxPointRegionMean(Observed, ChannelIndex, Region);
+		const float BaselineMean = ComputeBoxPointRegionMean(Baseline, ChannelIndex, Region);
+		const float Delta = ObservedMean - BaselineMean;
 		return Test.TestTrue(
 			FString::Printf(
-				TEXT("%s: channel %d bright-region mean %.3f should exceed dim-region mean %.3f by >= %.3f"),
+				TEXT("%s: channel %d region delta %.3f (observed %.3f - baseline %.3f) should be >= %.3f"),
 				Context,
 				ChannelIndex,
-				BrightMean,
-				DimMean,
+				Delta,
+				ObservedMean,
+				BaselineMean,
 				MinDelta),
-			(BrightMean - DimMean) >= MinDelta);
+			Delta >= MinDelta);
+	}
+
+	bool AssertBoxPointRegionDominantChannel(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 DominantChannelIndex,
+		const FIntRect& Region,
+		const TCHAR* Context)
+	{
+		const float DominantMean = ComputeBoxPointRegionMean(BoxPoint, DominantChannelIndex, Region);
+		bool bOk = true;
+		for (int32 ChannelIndex = 0; ChannelIndex < BoxPoint.Shape[0]; ++ChannelIndex)
+		{
+			if (ChannelIndex == DominantChannelIndex)
+			{
+				continue;
+			}
+
+			const float OtherMean = ComputeBoxPointRegionMean(BoxPoint, ChannelIndex, Region);
+			bOk &= Test.TestTrue(
+				FString::Printf(
+					TEXT("%s: channel %d mean %.3f should exceed channel %d mean %.3f"),
+					Context,
+					DominantChannelIndex,
+					DominantMean,
+					ChannelIndex,
+					OtherMean),
+				DominantMean > OtherMean);
+		}
+		return bOk;
 	}
 
 	UCameraSensor* SpawnCameraSensor(
@@ -367,6 +399,30 @@ namespace ScholaCameraSensorTest
 		MeshComponent->SetMaterial(0, DynamicMaterial);
 
 		return MeshComponent;
+	}
+
+	void DestroyColoredCube(UStaticMeshComponent* CubeComponent, FScholaCameraSensorTestWorld& TestWorld)
+	{
+		if (!CubeComponent)
+		{
+			return;
+		}
+
+		if (AActor* Owner = CubeComponent->GetOwner())
+		{
+			Owner->Destroy();
+		}
+
+		SettleScene(TestWorld);
+	}
+
+	void SettleScene(FScholaCameraSensorTestWorld& TestWorld, int32 TickCount)
+	{
+		for (int32 i = 0; i < TickCount; ++i)
+		{
+			TestWorld.Tick(0.016f);
+		}
+		FlushRenderingCommands();
 	}
 
 	void CaptureAndCollect(UCameraSensor* Sensor, FScholaCameraSensorTestWorld& TestWorld, FInstancedStruct& OutObservations)

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
@@ -45,6 +45,12 @@ struct FScholaCameraSensorTestWorld
 
 namespace ScholaCameraSensorTest
 {
+	/** Minimum channel mean increase vs a baseline capture for spatial colour checks. */
+	constexpr float CaptureSpatialMinChannelDelta = 0.08f;
+
+	/** Ticks to wait after spawning or destroying scene geometry before capture. */
+	constexpr int32 CaptureSettleTickCount = 5;
+
 	/** Row-major FColor bitmap with R=(w,h) and G=(h,w) encodings for layout checks. */
 	void BuildKnownColorBitmap(int32 Width, int32 Height, TArray<FColor>& OutBitmap);
 
@@ -96,23 +102,26 @@ namespace ScholaCameraSensorTest
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
 		const FIntRect& Region);
+	/**
+	 * @brief Assert that a channel mean in @p Region rose by at least @p MinDelta vs baseline.
+	 */
+	bool AssertBoxPointRegionChannelDeltaFromBaseline(
+		FAutomationTestBase& Test,
+		const FBoxPoint& Observed,
+		const FBoxPoint& Baseline,
+		int32 ChannelIndex,
+		const FIntRect& Region,
+		float MinDelta,
+		const TCHAR* Context);
 
 	/**
-	 * @brief Assert that a channel is brighter in one image region than another.
-	 *
-	 * Useful for spatial-localization checks (e.g. a cube rendered in the centre of the frame
-	 * should be brighter than the background corners). Compares mean(BrightRegion) against
-	 * mean(DimRegion) and requires the difference to be at least MinDelta.
-	 *
-	 * @return True if mean(BrightRegion) - mean(DimRegion) >= MinDelta.
+	 * @brief Assert that one channel mean exceeds the other two in @p Region.
 	 */
-	bool AssertBoxPointRegionBrighter(
+	bool AssertBoxPointRegionDominantChannel(
 		FAutomationTestBase& Test,
 		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		const FIntRect& BrightRegion,
-		const FIntRect& DimRegion,
-		float MinDelta,
+		int32 DominantChannelIndex,
+		const FIntRect& Region,
 		const TCHAR* Context);
 
 	UCameraSensor* SpawnCameraSensor(
@@ -130,8 +139,12 @@ namespace ScholaCameraSensorTest
 		UWorld* World,
 		const FVector& Location,
 		const FLinearColor& Color,
-		const FVector& Scale = FVector(100.0f),
+		const FVector& Scale = FVector(1.0f),
 		UStaticMesh* CubeMesh = nullptr);
+
+	void DestroyColoredCube(UStaticMeshComponent* CubeComponent, FScholaCameraSensorTestWorld& TestWorld);
+
+	void SettleScene(FScholaCameraSensorTestWorld& TestWorld, int32 TickCount = CaptureSettleTickCount);
 
 	void CaptureAndCollect(UCameraSensor* Sensor, FScholaCameraSensorTestWorld& TestWorld, FInstancedStruct& OutObservations);
 

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
@@ -63,16 +63,11 @@ namespace ScholaCameraSensorTest
 		int32 Width,
 		int32 Height);
 
-	/** Flush pending render commands after GPU writes or scene capture. */
-	void FlushRendering();
-
 	float GetBoxPointChannelValue(
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
 		int32 PixelY,
-		int32 PixelX,
-		int32 Width,
-		int32 Height);
+		int32 PixelX);
 
 	bool AssertBoxPointShape(
 		FAutomationTestBase& Test,
@@ -88,36 +83,8 @@ namespace ScholaCameraSensorTest
 		int32 ChannelIndex,
 		int32 PixelY,
 		int32 PixelX,
-		int32 Width,
-		int32 Height,
 		float ExpectedValue,
 		float Tolerance,
-		const TCHAR* Context);
-
-	bool AssertBoxPointRegionMeanAbove(
-		FAutomationTestBase& Test,
-		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
-		int32 Width,
-		int32 Height,
-		float MinMean,
-		const TCHAR* Context);
-
-	bool AssertBoxPointRegionMeanBelow(
-		FAutomationTestBase& Test,
-		const FBoxPoint& BoxPoint,
-		int32 ChannelIndex,
-		int32 StartY,
-		int32 EndY,
-		int32 StartX,
-		int32 EndX,
-		int32 Width,
-		int32 Height,
-		float MaxMean,
 		const TCHAR* Context);
 
 	/**
@@ -128,9 +95,7 @@ namespace ScholaCameraSensorTest
 	float ComputeBoxPointRegionMean(
 		const FBoxPoint& BoxPoint,
 		int32 ChannelIndex,
-		const FIntRect& Region,
-		int32 Width,
-		int32 Height);
+		const FIntRect& Region);
 
 	/**
 	 * @brief Assert that a channel is brighter in one image region than another.
@@ -147,8 +112,6 @@ namespace ScholaCameraSensorTest
 		int32 ChannelIndex,
 		const FIntRect& BrightRegion,
 		const FIntRect& DimRegion,
-		int32 Width,
-		int32 Height,
 		float MinDelta,
 		const TCHAR* Context);
 

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
@@ -120,6 +120,38 @@ namespace ScholaCameraSensorTest
 		float MaxMean,
 		const TCHAR* Context);
 
+	/**
+	 * @brief Mean of a single channel over the half-open pixel rect [Min, Max).
+	 *
+	 * Region is expressed in image pixel coordinates (X = column, Y = row).
+	 */
+	float ComputeBoxPointRegionMean(
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		const FIntRect& Region,
+		int32 Width,
+		int32 Height);
+
+	/**
+	 * @brief Assert that a channel is brighter in one image region than another.
+	 *
+	 * Useful for spatial-localization checks (e.g. a cube rendered in the centre of the frame
+	 * should be brighter than the background corners). Compares mean(BrightRegion) against
+	 * mean(DimRegion) and requires the difference to be at least MinDelta.
+	 *
+	 * @return True if mean(BrightRegion) - mean(DimRegion) >= MinDelta.
+	 */
+	bool AssertBoxPointRegionBrighter(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		const FIntRect& BrightRegion,
+		const FIntRect& DimRegion,
+		int32 Width,
+		int32 Height,
+		float MinDelta,
+		const TCHAR* Context);
+
 	UCameraSensor* SpawnCameraSensor(
 		UWorld* World,
 		const FVector& Location,

--- a/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
+++ b/Source/ScholaEditor/Private/Test/Sensors/CameraSensorTestHelpers.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+
+#include "Engine/TextureRenderTarget2D.h"
+#include "Points/BoxPoint.h"
+#include "Sensors/CameraSensor.h"
+
+class UStaticMesh;
+class UStaticMeshComponent;
+
+/**
+ * RAII wrapper around FTestWorldWrapper for camera sensor tests: creates a dedicated game world,
+ * runs BeginPlay, ticks a few frames, then EndPlay + Destroy on scope exit.
+ */
+struct FScholaCameraSensorTestWorld
+{
+	enum class EPhase : uint8
+	{
+		None,
+		Created,
+		Playing,
+	};
+
+	FTestWorldWrapper Wrapper;
+	FAutomationTestBase* Test = nullptr;
+	EPhase Phase = EPhase::None;
+
+	bool Setup(FAutomationTestBase* InTest);
+
+	void Tick(float DeltaSeconds = 0.016f);
+
+	UWorld* GetWorld() const { return Wrapper.GetTestWorld(); }
+
+	~FScholaCameraSensorTestWorld();
+
+	FScholaCameraSensorTestWorld() = default;
+	FScholaCameraSensorTestWorld(const FScholaCameraSensorTestWorld&) = delete;
+	FScholaCameraSensorTestWorld& operator=(const FScholaCameraSensorTestWorld&) = delete;
+};
+
+namespace ScholaCameraSensorTest
+{
+	/** Row-major FColor bitmap with R=(w,h) and G=(h,w) encodings for layout checks. */
+	void BuildKnownColorBitmap(int32 Width, int32 Height, TArray<FColor>& OutBitmap);
+
+	UTextureRenderTarget2D* CreateInitializedRenderTarget(
+		UObject* Outer,
+		int32 Width,
+		int32 Height,
+		ETextureRenderTargetFormat Format = ETextureRenderTargetFormat::RTF_RGBA8);
+
+	bool FillRenderTargetSolidColor(UWorld* World, UTextureRenderTarget2D* RenderTarget, const FLinearColor& Color);
+
+	bool FillRenderTargetFromBitmap(
+		UWorld* World,
+		UTextureRenderTarget2D* RenderTarget,
+		const TArray<FColor>& Bitmap,
+		int32 Width,
+		int32 Height);
+
+	/** Flush pending render commands after GPU writes or scene capture. */
+	void FlushRendering();
+
+	float GetBoxPointChannelValue(
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 PixelY,
+		int32 PixelX,
+		int32 Width,
+		int32 Height);
+
+	bool AssertBoxPointShape(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ExpectedChannels,
+		int32 ExpectedHeight,
+		int32 ExpectedWidth,
+		const TCHAR* Context);
+
+	bool AssertBoxPointChannelNear(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 PixelY,
+		int32 PixelX,
+		int32 Width,
+		int32 Height,
+		float ExpectedValue,
+		float Tolerance,
+		const TCHAR* Context);
+
+	bool AssertBoxPointRegionMeanAbove(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height,
+		float MinMean,
+		const TCHAR* Context);
+
+	bool AssertBoxPointRegionMeanBelow(
+		FAutomationTestBase& Test,
+		const FBoxPoint& BoxPoint,
+		int32 ChannelIndex,
+		int32 StartY,
+		int32 EndY,
+		int32 StartX,
+		int32 EndX,
+		int32 Width,
+		int32 Height,
+		float MaxMean,
+		const TCHAR* Context);
+
+	UCameraSensor* SpawnCameraSensor(
+		UWorld* World,
+		const FVector& Location,
+		const FRotator& Rotation,
+		int32 RenderTargetWidth = 64,
+		int32 RenderTargetHeight = 64,
+		ESceneCaptureSource CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR,
+		uint8 EnabledChannels = 15,
+		bool bCallInitSensor = true,
+		bool bCreateRenderTarget = true);
+
+	UStaticMeshComponent* SpawnColoredCube(
+		UWorld* World,
+		const FVector& Location,
+		const FLinearColor& Color,
+		const FVector& Scale = FVector(100.0f),
+		UStaticMesh* CubeMesh = nullptr);
+
+	void CaptureAndCollect(UCameraSensor* Sensor, FScholaCameraSensorTestWorld& TestWorld, FInstancedStruct& OutObservations);
+
+	uint8 GetEnabledValidChannels(const UCameraSensor* Sensor);
+}

--- a/Source/ScholaEditor/ScholaEditor.Build.cs
+++ b/Source/ScholaEditor/ScholaEditor.Build.cs
@@ -19,7 +19,7 @@ public class ScholaEditor : ModuleRules
 		PublicDependencyModuleNames.AddRange(new string[] { "Kismet", "NNE", "BlueprintEditorLibrary", "Schola", "KismetCompiler", });
 
 		PrivateIncludePathModuleNames.AddRange(new string[] { });
-        PrivateDependencyModuleNames.AddRange(new string[] { "AIModule", "Engine", "Core", "BlueprintGraph", "UnrealEd", "CoreUObject", "AutomationController", "KismetCompiler", "Schola", "ScholaInteractors", "gRPC", "ScholaTraining", "Slate", "SlateCore", "ToolMenus" });
+        PrivateDependencyModuleNames.AddRange(new string[] { "AIModule", "Engine", "Core", "BlueprintGraph", "UnrealEd", "CoreUObject", "AutomationController", "KismetCompiler", "Schola", "ScholaInteractors", "gRPC", "ScholaTraining", "Slate", "SlateCore", "ToolMenus", "RenderCore", "RHI" });
 		DynamicallyLoadedModuleNames.AddRange(new string[] { });
 	}
 }

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
@@ -46,13 +46,7 @@ void UCameraSensor::GetObservationSpace_Implementation(FInstancedStruct& OutObse
 
 int UCameraSensor::GetNumChannels() const
 {
-	uint8 EnabledValidChannels = EnabledChannels & ~GetInvalidChannels();
-	bool  bHasR = (EnabledValidChannels & static_cast<uint8>(EChannels::R));
-	bool  bHasG = (EnabledValidChannels & static_cast<uint8>(EChannels::G));
-	bool  bHasB = (EnabledValidChannels & static_cast<uint8>(EChannels::B));
-	bool  bHasA = (EnabledValidChannels & static_cast<uint8>(EChannels::A));
-
-	return (bHasR + bHasG + bHasB + bHasA);
+	return FMath::CountBits(EnabledChannels & ~GetInvalidChannels());
 }
 
 void UCameraSensor::CollectObservations_Implementation(FInstancedStruct& OutObservations)
@@ -91,23 +85,24 @@ FString UCameraSensor::GenerateId() const
 	Output.Append("_");
 	//Add channels to Id
 	uint8 InvalidChannels = GetInvalidChannels();
+	uint8 EnabledValidChannels = EnabledChannels & ~InvalidChannels;
 
-	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::R))
+	if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
 	{
 		Output = Output.Append("R");
 	}
 	
-	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::G))
+	if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
 	{
 		Output = Output.Append("G");
 	}
 
-	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::B))
+	if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
 	{
 		Output = Output.Append("B");
 	}
 
-	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::A))
+	if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
 	{
 		Output = Output.Append("A");
 	}

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
 
 #include "Sensors/CameraSensor.h"
+#include "Sensors/CameraSensorUtils.h"
 #include "LogScholaInteractors.h"
 #include "RHICommandList.h"
 
@@ -26,12 +27,12 @@ void UCameraSensor::GetObservationSpace_Implementation(FInstancedStruct& OutObse
 	int		  Height = TextureTarget->GetSurfaceHeight();
 	FBoxSpace SpaceDefinition;
 	int		  NumChannels = GetNumChannels();
-	SpaceDefinition.Dimensions.Init(FBoxSpaceDimension(0.0, 1.0), Width * Height * (this->GetNumChannels()));
+	SpaceDefinition.Dimensions.Init(FBoxSpaceDimension(0.0, 1.0), Width * Height * NumChannels);
 	
 	// If a channel is in InvalidChannels, it cannot be observed, or if the channel hasn't been filtered
 	// e.g. Channels = R|G, InvalidChannels = A, bHasR will be True but bHasA will be False
 
-	SpaceDefinition.Shape = { this->GetNumChannels(), Height, Width };
+	SpaceDefinition.Shape = { NumChannels, Height, Width };
 
 	OutObservationSpace.InitializeAs<FBoxSpace>(MoveTemp(SpaceDefinition));
 }
@@ -55,45 +56,13 @@ void UCameraSensor::CollectObservations_Implementation(FInstancedStruct& OutObse
 		return;
 	}
 
-	TArray<float> ObservationValues;
 	OutObservations.InitializeAs<FBoxPoint>();
 	FBoxPoint& OutBoxPoint = OutObservations.GetMutable<FBoxPoint>();
 
-	TArray<FColor> Bitmap;
-	int		   Width = TextureTarget->GetSurfaceWidth();
-	int		   Height = TextureTarget->GetSurfaceHeight();
-    OutBoxPoint.Values.AddUninitialized(Width * Height * this->GetNumChannels());
-	OutBoxPoint.Shape = {this->GetNumChannels(), Width, Height};
-
-	TextureTarget->GameThread_GetRenderTargetResource()->ReadPixels(Bitmap);
-	
-	uint8 InvalidChannels = GetInvalidChannels();
-
-	for (int i = 0; i < Width*Height; i++)
-    {
-		int Index = i;
-		if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::R))
-		{
-			OutBoxPoint.Values[Index] = ((float)Bitmap[i].R / 255.0); // R
-			Index += Width*Height;
-		}
-		
-		if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::G))
-		{
-			OutBoxPoint.Values[Index] = ((float)Bitmap[i].G / 255.0); // G
-			Index += Width * Height;
-		}
-
-		if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::B))
-		{
-			OutBoxPoint.Values[Index] = ((float)Bitmap[i].B / 255.0); // B
-			Index += Width * Height;
-		}
-
-		if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::A))
-		{
-			OutBoxPoint.Values[Index] = ((float)Bitmap[i].A / 255.0); // A
-		}
+	const uint8 EnabledValidChannels = EnabledChannels & ~GetInvalidChannels();
+	if (!FCameraSensorUtils::ReadRenderTargetToBoxPoint(TextureTarget, EnabledValidChannels, OutBoxPoint))
+	{
+		UE_LOGFMT(LogScholaInteractors, Error, "UCameraSensor::CollectObservations_Implementation(): Failed to read render target into observations.");
 	}
 }
 

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
@@ -85,22 +85,22 @@ FString UCameraSensor::GenerateId() const
 	//Add channels to Id
 	uint8 InvalidChannels = GetInvalidChannels();
 
-	if (EnabledChannels & !InvalidChannels & static_cast<uint8>(EChannels::R))
+	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::R))
 	{
 		Output = Output.Append("R");
 	}
 	
-	if (EnabledChannels & !InvalidChannels & static_cast<uint8>(EChannels::G))
+	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::G))
 	{
 		Output = Output.Append("G");
 	}
 
-	if (EnabledChannels & !InvalidChannels & static_cast<uint8>(EChannels::B))
+	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::B))
 	{
 		Output = Output.Append("B");
 	}
 
-	if (EnabledChannels & !InvalidChannels & static_cast<uint8>(EChannels::A))
+	if (EnabledChannels & ~InvalidChannels & static_cast<uint8>(EChannels::A))
 	{
 		Output = Output.Append("A");
 	}

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
@@ -67,7 +67,7 @@ void UCameraSensor::CollectObservations_Implementation(FInstancedStruct& OutObse
 	FBoxPoint& OutBoxPoint = OutObservations.GetMutable<FBoxPoint>();
 
 	const uint8 EnabledValidChannels = EnabledChannels & ~GetInvalidChannels();
-	if (!FCameraSensorUtils::ReadRenderTargetToBoxPoint(TextureTarget, EnabledValidChannels, OutBoxPoint))
+	if (!CameraSensorUtils::ReadRenderTargetToBoxPoint(TextureTarget, EnabledValidChannels, OutBoxPoint))
 	{
 		UE_LOGFMT(LogScholaInteractors, Error, "UCameraSensor::CollectObservations_Implementation(): Failed to read render target into observations.");
 	}

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensor.cpp
@@ -23,6 +23,13 @@ void UCameraSensor::InitSensor_Implementation()
 
 void UCameraSensor::GetObservationSpace_Implementation(FInstancedStruct& OutObservationSpace) const
 {
+	if (!TextureTarget)
+	{
+		UE_LOGFMT(LogScholaInteractors, Error, "UCameraSensor::GetObservationSpace_Implementation(): RenderTarget not found. Returning empty observation space.");
+		OutObservationSpace.InitializeAs<FBoxSpace>();
+		return;
+	}
+
 	int		  Width = TextureTarget->GetSurfaceWidth();
 	int		  Height = TextureTarget->GetSurfaceHeight();
 	FBoxSpace SpaceDefinition;
@@ -106,7 +113,10 @@ FString UCameraSensor::GenerateId() const
 	}
 
 	//Add width and height
-	Output = Output.Appendf(TEXT("_W%.3f_H%.3f"), TextureTarget->GetSurfaceWidth(), TextureTarget->GetSurfaceHeight()); // Width and Height
+	if (this->TextureTarget)
+	{
+		Output = Output.Appendf(TEXT("_W%.3f_H%.3f"), TextureTarget->GetSurfaceWidth(), TextureTarget->GetSurfaceHeight()); // Width and Height
+	}
 	return Output;
 }
 

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
@@ -5,38 +5,13 @@
 #include "Engine/TextureRenderTarget2D.h"
 #include "LogScholaInteractors.h"
 
-namespace
-{
-	int32 CountEnabledChannels(uint8 EnabledValidChannels)
-	{
-		int32 NumChannels = 0;
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
-		{
-			++NumChannels;
-		}
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
-		{
-			++NumChannels;
-		}
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
-		{
-			++NumChannels;
-		}
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
-		{
-			++NumChannels;
-		}
-		return NumChannels;
-	}
-}
-
 namespace CameraSensorUtils
 {
 	bool ConvertBitmapToBoxPoint(
 		const TArray<FColor>& Bitmap,
 		int32 Width,
 		int32 Height,
-		uint8 EnabledValidChannels,
+		uint8 ChannelMask,
 		FBoxPoint& OutBoxPoint)
 	{
 		const int32 ChannelStride = Width * Height;
@@ -52,49 +27,45 @@ namespace CameraSensorUtils
 			return false;
 		}
 
-		const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
-
-		OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
-		OutBoxPoint.Shape = { NumChannels, Height, Width };
+		const int32 NumChannels = FMath::CountBits(ChannelMask);
+        OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
+        OutBoxPoint.Shape = { NumChannels, Height, Width };
 
 		for (int32 PixelIndex = 0; PixelIndex < ChannelStride; ++PixelIndex)
-		{
+        {
 			int32 ChannelIndex = 0;
+			const FLinearColor& Color = Bitmap[PixelIndex].ReinterpretAsLinear();
 
-			if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
-			{
-				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-					static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
+			if (ChannelMask & static_cast<uint8>(EChannels::R))
+        	{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] = Color.R;
 				++ChannelIndex;
-			}
+        	}
 
-			if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
-			{
-				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-					static_cast<float>(Bitmap[PixelIndex].G) / 255.0f;
+			if (ChannelMask & static_cast<uint8>(EChannels::G))
+        	{
+        		OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] = Color.G;
 				++ChannelIndex;
+        	}
+
+			if (ChannelMask & static_cast<uint8>(EChannels::B))
+			{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] = Color.B;
+        		++ChannelIndex;
 			}
 
-			if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
+			if (ChannelMask & static_cast<uint8>(EChannels::A))
 			{
-				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-					static_cast<float>(Bitmap[PixelIndex].B) / 255.0f;
-				++ChannelIndex;
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] = Color.A;
 			}
-
-			if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
-			{
-				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-					static_cast<float>(Bitmap[PixelIndex].A) / 255.0f;
-			}
-		}
+        }
 
 		return true;
 	}
 
 	bool ReadRenderTargetToBoxPoint(
 		UTextureRenderTarget2D* TextureTarget,
-		uint8 EnabledValidChannels,
+		uint8 ChannelMask,
 		FBoxPoint& OutBoxPoint)
 	{
 		if (!TextureTarget)
@@ -120,6 +91,6 @@ namespace CameraSensorUtils
 			return false;
 		}
 
-		return ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
+		return ConvertBitmapToBoxPoint(Bitmap, Width, Height, ChannelMask, OutBoxPoint);
 	}
 }

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
@@ -30,93 +30,96 @@ namespace
 	}
 }
 
-bool FCameraSensorUtils::ConvertBitmapToBoxPoint(
-	const TArray<FColor>& Bitmap,
-	int32 Width,
-	int32 Height,
-	uint8 EnabledValidChannels,
-	FBoxPoint& OutBoxPoint)
+namespace FCameraSensorUtils
 {
-	const int32 ChannelStride = Width * Height;
-
-	if (Bitmap.Num() != ChannelStride)
+	bool ConvertBitmapToBoxPoint(
+		const TArray<FColor>& Bitmap,
+		int32 Width,
+		int32 Height,
+		uint8 EnabledValidChannels,
+		FBoxPoint& OutBoxPoint)
 	{
-		UE_LOGFMT(
-			LogScholaInteractors,
-			Error,
-			"FCameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
-			Bitmap.Num(),
-			ChannelStride);
-		return false;
-	}
+		const int32 ChannelStride = Width * Height;
 
-	const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
-
-	OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
-	OutBoxPoint.Shape = { NumChannels, Height, Width };
-
-	for (int32 PixelIndex = 0; PixelIndex < ChannelStride; ++PixelIndex)
-	{
-		int32 ChannelIndex = 0;
-
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
+		if (Bitmap.Num() != ChannelStride)
 		{
-			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-				static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
-			++ChannelIndex;
+			UE_LOGFMT(
+				LogScholaInteractors,
+				Error,
+				"FCameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
+				Bitmap.Num(),
+				ChannelStride);
+			return false;
 		}
 
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
+		const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
+
+		OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
+		OutBoxPoint.Shape = { NumChannels, Height, Width };
+
+		for (int32 PixelIndex = 0; PixelIndex < ChannelStride; ++PixelIndex)
 		{
-			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-				static_cast<float>(Bitmap[PixelIndex].G) / 255.0f;
-			++ChannelIndex;
+			int32 ChannelIndex = 0;
+
+			if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
+			{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+					static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
+				++ChannelIndex;
+			}
+
+			if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
+			{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+					static_cast<float>(Bitmap[PixelIndex].G) / 255.0f;
+				++ChannelIndex;
+			}
+
+			if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
+			{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+					static_cast<float>(Bitmap[PixelIndex].B) / 255.0f;
+				++ChannelIndex;
+			}
+
+			if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
+			{
+				OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+					static_cast<float>(Bitmap[PixelIndex].A) / 255.0f;
+			}
 		}
 
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
+		return true;
+	}
+
+	bool ReadRenderTargetToBoxPoint(
+		UTextureRenderTarget2D* TextureTarget,
+		uint8 EnabledValidChannels,
+		FBoxPoint& OutBoxPoint)
+	{
+		if (!TextureTarget)
 		{
-			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-				static_cast<float>(Bitmap[PixelIndex].B) / 255.0f;
-			++ChannelIndex;
+			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): TextureTarget is null.");
+			return false;
 		}
 
-		if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
+		FTextureRenderTargetResource* Resource = TextureTarget->GameThread_GetRenderTargetResource();
+		if (!Resource)
 		{
-			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
-				static_cast<float>(Bitmap[PixelIndex].A) / 255.0f;
+			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): Render target resource is null.");
+			return false;
 		}
+
+		TArray<FColor> Bitmap;
+		const int32 Width = TextureTarget->GetSurfaceWidth();
+		const int32 Height = TextureTarget->GetSurfaceHeight();
+
+		if (!Resource->ReadPixels(Bitmap))
+		{
+			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): ReadPixels failed.");
+			return false;
+		}
+
+		return ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
 	}
-
-	return true;
-}
-
-bool FCameraSensorUtils::ReadRenderTargetToBoxPoint(
-	UTextureRenderTarget2D* TextureTarget,
-	uint8 EnabledValidChannels,
-	FBoxPoint& OutBoxPoint)
-{
-	if (!TextureTarget)
-	{
-		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): TextureTarget is null.");
-		return false;
-	}
-
-	FTextureRenderTargetResource* Resource = TextureTarget->GameThread_GetRenderTargetResource();
-	if (!Resource)
-	{
-		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): Render target resource is null.");
-		return false;
-	}
-
-	TArray<FColor> Bitmap;
-	const int32 Width = TextureTarget->GetSurfaceWidth();
-	const int32 Height = TextureTarget->GetSurfaceHeight();
-
-	if (!Resource->ReadPixels(Bitmap))
-	{
-		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): ReadPixels failed.");
-		return false;
-	}
-
-	return ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
 }

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "Sensors/CameraSensorUtils.h"
+#include "Sensors/CameraSensor.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "LogScholaInteractors.h"
+
+namespace
+{
+	int32 CountEnabledChannels(uint8 EnabledValidChannels)
+	{
+		int32 NumChannels = 0;
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
+		{
+			++NumChannels;
+		}
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
+		{
+			++NumChannels;
+		}
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
+		{
+			++NumChannels;
+		}
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
+		{
+			++NumChannels;
+		}
+		return NumChannels;
+	}
+}
+
+void FCameraSensorUtils::ConvertBitmapToBoxPoint(
+	const TArray<FColor>& Bitmap,
+	int32 Width,
+	int32 Height,
+	uint8 EnabledValidChannels,
+	FBoxPoint& OutBoxPoint)
+{
+	const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
+	const int32 ChannelStride = Width * Height;
+
+	OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
+	OutBoxPoint.Shape = { NumChannels, Height, Width };
+
+	if (Bitmap.Num() != ChannelStride)
+	{
+		UE_LOGFMT(
+			LogScholaInteractors,
+			Error,
+			"FCameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
+			Bitmap.Num(),
+			ChannelStride);
+		return;
+	}
+
+	for (int32 PixelIndex = 0; PixelIndex < ChannelStride; ++PixelIndex)
+	{
+		int32 ChannelIndex = 0;
+
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::R))
+		{
+			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+				static_cast<float>(Bitmap[PixelIndex].R) / 255.0f;
+			++ChannelIndex;
+		}
+
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::G))
+		{
+			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+				static_cast<float>(Bitmap[PixelIndex].G) / 255.0f;
+			++ChannelIndex;
+		}
+
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::B))
+		{
+			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+				static_cast<float>(Bitmap[PixelIndex].B) / 255.0f;
+			++ChannelIndex;
+		}
+
+		if (EnabledValidChannels & static_cast<uint8>(EChannels::A))
+		{
+			OutBoxPoint.Values[ChannelIndex * ChannelStride + PixelIndex] =
+				static_cast<float>(Bitmap[PixelIndex].A) / 255.0f;
+		}
+	}
+}
+
+bool FCameraSensorUtils::ReadRenderTargetToBoxPoint(
+	UTextureRenderTarget2D* TextureTarget,
+	uint8 EnabledValidChannels,
+	FBoxPoint& OutBoxPoint)
+{
+	if (!TextureTarget)
+	{
+		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): TextureTarget is null.");
+		return false;
+	}
+
+	FTextureRenderTargetResource* Resource = TextureTarget->GameThread_GetRenderTargetResource();
+	if (!Resource)
+	{
+		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): Render target resource is null.");
+		return false;
+	}
+
+	TArray<FColor> Bitmap;
+	const int32 Width = TextureTarget->GetSurfaceWidth();
+	const int32 Height = TextureTarget->GetSurfaceHeight();
+
+	if (!Resource->ReadPixels(Bitmap))
+	{
+		UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): ReadPixels failed.");
+		return false;
+	}
+
+	ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
+	return true;
+}

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
@@ -30,18 +30,14 @@ namespace
 	}
 }
 
-void FCameraSensorUtils::ConvertBitmapToBoxPoint(
+bool FCameraSensorUtils::ConvertBitmapToBoxPoint(
 	const TArray<FColor>& Bitmap,
 	int32 Width,
 	int32 Height,
 	uint8 EnabledValidChannels,
 	FBoxPoint& OutBoxPoint)
 {
-	const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
 	const int32 ChannelStride = Width * Height;
-
-	OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
-	OutBoxPoint.Shape = { NumChannels, Height, Width };
 
 	if (Bitmap.Num() != ChannelStride)
 	{
@@ -51,8 +47,13 @@ void FCameraSensorUtils::ConvertBitmapToBoxPoint(
 			"FCameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
 			Bitmap.Num(),
 			ChannelStride);
-		return;
+		return false;
 	}
+
+	const int32 NumChannels = CountEnabledChannels(EnabledValidChannels);
+
+	OutBoxPoint.Values.SetNum(ChannelStride * NumChannels);
+	OutBoxPoint.Shape = { NumChannels, Height, Width };
 
 	for (int32 PixelIndex = 0; PixelIndex < ChannelStride; ++PixelIndex)
 	{
@@ -85,6 +86,8 @@ void FCameraSensorUtils::ConvertBitmapToBoxPoint(
 				static_cast<float>(Bitmap[PixelIndex].A) / 255.0f;
 		}
 	}
+
+	return true;
 }
 
 bool FCameraSensorUtils::ReadRenderTargetToBoxPoint(
@@ -115,6 +118,5 @@ bool FCameraSensorUtils::ReadRenderTargetToBoxPoint(
 		return false;
 	}
 
-	ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
-	return true;
+	return ConvertBitmapToBoxPoint(Bitmap, Width, Height, EnabledValidChannels, OutBoxPoint);
 }

--- a/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
+++ b/Source/ScholaInteractors/Private/Sensors/CameraSensorUtils.cpp
@@ -30,7 +30,7 @@ namespace
 	}
 }
 
-namespace FCameraSensorUtils
+namespace CameraSensorUtils
 {
 	bool ConvertBitmapToBoxPoint(
 		const TArray<FColor>& Bitmap,
@@ -46,7 +46,7 @@ namespace FCameraSensorUtils
 			UE_LOGFMT(
 				LogScholaInteractors,
 				Error,
-				"FCameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
+				"CameraSensorUtils::ConvertBitmapToBoxPoint(): Bitmap size ({0}) does not match Width * Height ({1}).",
 				Bitmap.Num(),
 				ChannelStride);
 			return false;
@@ -99,14 +99,14 @@ namespace FCameraSensorUtils
 	{
 		if (!TextureTarget)
 		{
-			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): TextureTarget is null.");
+			UE_LOGFMT(LogScholaInteractors, Error, "CameraSensorUtils::ReadRenderTargetToBoxPoint(): TextureTarget is null.");
 			return false;
 		}
 
 		FTextureRenderTargetResource* Resource = TextureTarget->GameThread_GetRenderTargetResource();
 		if (!Resource)
 		{
-			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): Render target resource is null.");
+			UE_LOGFMT(LogScholaInteractors, Error, "CameraSensorUtils::ReadRenderTargetToBoxPoint(): Render target resource is null.");
 			return false;
 		}
 
@@ -116,7 +116,7 @@ namespace FCameraSensorUtils
 
 		if (!Resource->ReadPixels(Bitmap))
 		{
-			UE_LOGFMT(LogScholaInteractors, Error, "FCameraSensorUtils::ReadRenderTargetToBoxPoint(): ReadPixels failed.");
+			UE_LOGFMT(LogScholaInteractors, Error, "CameraSensorUtils::ReadRenderTargetToBoxPoint(): ReadPixels failed.");
 			return false;
 		}
 

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -570,5 +570,175 @@ bool FCameraSensorUtils_ConvertBitmap_NoTranspose_Test::RunTest(const FString& P
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorUtils_ConvertBitmap_AllChannelMasks_Test,
+	"Schola.Sensors.CameraSensorUtils.ConvertBitmap.AllChannelMasks",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensorUtils_ConvertBitmap_AllChannelMasks_Test::RunTest(const FString& Parameters)
+{
+	constexpr int32 Width = 2;
+	constexpr int32 Height = 2;
+	TArray<FColor> Bitmap;
+	Bitmap.Init(FColor(10, 20, 30, 40), Width * Height);
+
+	const uint8 ChannelMasks[] = {
+		static_cast<uint8>(EChannels::R),
+		static_cast<uint8>(EChannels::G),
+		static_cast<uint8>(EChannels::B),
+		static_cast<uint8>(EChannels::A),
+		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B) | static_cast<uint8>(EChannels::A),
+	};
+
+	const float ExpectedValues[4] = { 10.0f / 255.0f, 20.0f / 255.0f, 30.0f / 255.0f, 40.0f / 255.0f };
+
+	for (uint8 Mask : ChannelMasks)
+	{
+		FBoxPoint BoxPoint;
+		FCameraSensorUtils::ConvertBitmapToBoxPoint(Bitmap, Width, Height, Mask, BoxPoint);
+
+		int32 ExpectedChannels = 0;
+		if (Mask & static_cast<uint8>(EChannels::R)) { ++ExpectedChannels; }
+		if (Mask & static_cast<uint8>(EChannels::G)) { ++ExpectedChannels; }
+		if (Mask & static_cast<uint8>(EChannels::B)) { ++ExpectedChannels; }
+		if (Mask & static_cast<uint8>(EChannels::A)) { ++ExpectedChannels; }
+
+		TestEqual(FString::Printf(TEXT("Channel count for mask %d"), Mask), BoxPoint.Shape[0], ExpectedChannels);
+		TestEqual(FString::Printf(TEXT("Value count for mask %d"), Mask), BoxPoint.Values.Num(), ExpectedChannels * Width * Height);
+
+		int32 ChannelIndex = 0;
+		if (Mask & static_cast<uint8>(EChannels::R))
+		{
+			TestEqual(FString::Printf(TEXT("R for mask %d"), Mask), BoxPoint.Values[ChannelIndex * Width * Height], ExpectedValues[0]);
+			++ChannelIndex;
+		}
+		if (Mask & static_cast<uint8>(EChannels::G))
+		{
+			TestEqual(FString::Printf(TEXT("G for mask %d"), Mask), BoxPoint.Values[ChannelIndex * Width * Height], ExpectedValues[1]);
+			++ChannelIndex;
+		}
+		if (Mask & static_cast<uint8>(EChannels::B))
+		{
+			TestEqual(FString::Printf(TEXT("B for mask %d"), Mask), BoxPoint.Values[ChannelIndex * Width * Height], ExpectedValues[2]);
+			++ChannelIndex;
+		}
+		if (Mask & static_cast<uint8>(EChannels::A))
+		{
+			TestEqual(FString::Printf(TEXT("A for mask %d"), Mask), BoxPoint.Values[ChannelIndex * Width * Height], ExpectedValues[3]);
+		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorUtils_ConvertBitmap_Normalization_Test,
+	"Schola.Sensors.CameraSensorUtils.ConvertBitmap.Normalization",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensorUtils_ConvertBitmap_Normalization_Test::RunTest(const FString& Parameters)
+{
+	TArray<FColor> Bitmap = { FColor(0, 127, 255, 255) };
+
+	FBoxPoint BoxPoint;
+	FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		Bitmap,
+		1,
+		1,
+		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B),
+		BoxPoint);
+
+	TestEqual(TEXT("Zero normalizes to 0"), BoxPoint.Values[0], 0.0f);
+	TestEqual(TEXT("127 normalizes correctly"), BoxPoint.Values[1], 127.0f / 255.0f);
+	TestEqual(TEXT("255 normalizes to 1"), BoxPoint.Values[2], 1.0f);
+
+	return true;
+}
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorUtils_ConvertBitmap_SizeMismatch_Test,
+	"Schola.Sensors.CameraSensorUtils.ConvertBitmap.SizeMismatch",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensorUtils_ConvertBitmap_SizeMismatch_Test::RunTest(const FString& Parameters)
+{
+	TArray<FColor> Bitmap = { FColor(255, 0, 0, 255), FColor(0, 255, 0, 255) };
+
+	FBoxPoint BoxPoint;
+	FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		Bitmap,
+		1,
+		1,
+		static_cast<uint8>(EChannels::R),
+		BoxPoint);
+
+	TestEqual(TEXT("Mismatch leaves values unallocated"), BoxPoint.Values.Num(), 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensor_GenerateId_FinalColorLDR_Test,
+	"Schola.Sensors.CameraSensor.GenerateId.FinalColorLDR",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensor_GenerateId_FinalColorLDR_Test::RunTest(const FString& Parameters)
+{
+	UCameraSensor* Sensor = CreateCameraSensorWithRenderTarget(
+		128,
+		128,
+		ETextureRenderTargetFormat::RTF_RGBA8,
+		ESceneCaptureSource::SCS_FinalColorLDR,
+		15);
+
+	const FString Id = Sensor->GenerateId();
+	TestTrue(TEXT("Id contains Camera prefix"), Id.Contains(TEXT("Camera")));
+	TestTrue(TEXT("Id contains capture source"), Id.Contains(TEXT("SCS_FinalColorLDR")));
+	TestTrue(TEXT("Id contains RGB channel suffix"), Id.Contains(TEXT("RGB_W128")));
+	TestTrue(TEXT("Id contains height"), Id.Contains(TEXT("H128")));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensor_GenerateId_SceneDepthR8_Test,
+	"Schola.Sensors.CameraSensor.GenerateId.SceneDepthR8",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensor_GenerateId_SceneDepthR8_Test::RunTest(const FString& Parameters)
+{
+	UCameraSensor* Sensor = CreateCameraSensorWithRenderTarget(
+		64,
+		64,
+		ETextureRenderTargetFormat::RTF_R8,
+		ESceneCaptureSource::SCS_SceneDepth,
+		15);
+
+	const FString Id = Sensor->GenerateId();
+	TestTrue(TEXT("Id contains R channel suffix before width"), Id.Contains(TEXT("R_W64")));
+	TestFalse(TEXT("Id excludes G channel suffix"), Id.Contains(TEXT("G_W64")));
+	TestFalse(TEXT("Id excludes B channel suffix"), Id.Contains(TEXT("B_W64")));
+	TestFalse(TEXT("Id excludes A channel suffix before width"), Id.Contains(TEXT("A_W64")));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensor_InitSensor_ExistingRenderTarget_Test,
+	"Schola.Sensors.CameraSensor.InitSensor.ExistingRenderTarget",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensor_InitSensor_ExistingRenderTarget_Test::RunTest(const FString& Parameters)
+{
+	UCameraSensor* Sensor = NewObject<UCameraSensor>();
+	UTextureRenderTarget2D* ExistingTarget = NewObject<UTextureRenderTarget2D>();
+	ExistingTarget->SizeX = 256;
+	ExistingTarget->SizeY = 128;
+	ExistingTarget->bNoFastClear = 1;
+	ExistingTarget->bHDR_DEPRECATED = 1;
+	Sensor->TextureTarget = ExistingTarget;
+
+	Sensor->InitSensor_Implementation();
+
+	TestEqual(TEXT("Existing render target preserved"), Sensor->TextureTarget.Get(), ExistingTarget);
+	TestEqual(TEXT("bNoFastClear cleared"), Sensor->TextureTarget->bNoFastClear, static_cast<uint8>(0));
+	TestEqual(TEXT("bHDR_DEPRECATED cleared"), Sensor->TextureTarget->bHDR_DEPRECATED, static_cast<uint8>(0));
+
+	return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS
 

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -536,7 +536,7 @@ bool FCameraSensorUtils_ConvertBitmap_NoTranspose_Test::RunTest(const FString& P
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ConvertBitmapToBoxPoint succeeds"),
-		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		CameraSensorUtils::ConvertBitmapToBoxPoint(
 			Bitmap,
 			Width,
 			Height,
@@ -598,7 +598,7 @@ bool FCameraSensorUtils_ConvertBitmap_AllChannelMasks_Test::RunTest(const FStrin
 		FBoxPoint BoxPoint;
 		TestTrue(
 			FString::Printf(TEXT("ConvertBitmapToBoxPoint succeeds for mask %d"), Mask),
-			FCameraSensorUtils::ConvertBitmapToBoxPoint(Bitmap, Width, Height, Mask, BoxPoint));
+			CameraSensorUtils::ConvertBitmapToBoxPoint(Bitmap, Width, Height, Mask, BoxPoint));
 
 		int32 ExpectedChannels = 0;
 		if (Mask & static_cast<uint8>(EChannels::R)) { ++ExpectedChannels; }
@@ -645,7 +645,7 @@ bool FCameraSensorUtils_ConvertBitmap_Normalization_Test::RunTest(const FString&
 	FBoxPoint BoxPoint;
 	TestTrue(
 		TEXT("ConvertBitmapToBoxPoint succeeds"),
-		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		CameraSensorUtils::ConvertBitmapToBoxPoint(
 			Bitmap,
 			1,
 			1,
@@ -674,7 +674,7 @@ bool FCameraSensorUtils_ConvertBitmap_SizeMismatch_Test::RunTest(const FString& 
 	FBoxPoint BoxPoint;
 	TestFalse(
 		TEXT("ConvertBitmapToBoxPoint fails on size mismatch"),
-		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		CameraSensorUtils::ConvertBitmapToBoxPoint(
 			Bitmap,
 			1,
 			1,

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -754,5 +754,28 @@ bool FCameraSensor_InitSensor_ExistingRenderTarget_Test::RunTest(const FString& 
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensor_GetObservationSpace_NullTarget_Test,
+	"Schola.Sensors.CameraSensor.ObservationSpace.NullTarget",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FCameraSensor_GetObservationSpace_NullTarget_Test::RunTest(const FString& Parameters)
+{
+	AddExpectedError(TEXT("RenderTarget not found. Returning empty observation space."), EAutomationExpectedErrorFlags::Contains, 1);
+
+	UCameraSensor* Sensor = NewObject<UCameraSensor>();
+	Sensor->TextureTarget = nullptr;
+
+	FInstancedStruct ObservationSpace;
+	Sensor->GetObservationSpace_Implementation(ObservationSpace);
+
+	TestTrue(TEXT("Observation space is a BoxSpace"), ObservationSpace.GetScriptStruct() == FBoxSpace::StaticStruct());
+
+	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
+	TestEqual(TEXT("Empty space has no dimensions"), Space.Dimensions.Num(), 0);
+	TestEqual(TEXT("Empty space has no shape"), Space.Shape.Num(), 0);
+
+	return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS
 

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -534,12 +534,14 @@ bool FCameraSensorUtils_ConvertBitmap_NoTranspose_Test::RunTest(const FString& P
 	}
 
 	FBoxPoint BoxPoint;
-	FCameraSensorUtils::ConvertBitmapToBoxPoint(
-		Bitmap,
-		Width,
-		Height,
-		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G),
-		BoxPoint);
+	TestTrue(
+		TEXT("ConvertBitmapToBoxPoint succeeds"),
+		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+			Bitmap,
+			Width,
+			Height,
+			static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G),
+			BoxPoint));
 
 	TestEqual(TEXT("Shape should have 3 dimensions"), BoxPoint.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 2 (channels)"), BoxPoint.Shape[0], 2);
@@ -594,7 +596,9 @@ bool FCameraSensorUtils_ConvertBitmap_AllChannelMasks_Test::RunTest(const FStrin
 	for (uint8 Mask : ChannelMasks)
 	{
 		FBoxPoint BoxPoint;
-		FCameraSensorUtils::ConvertBitmapToBoxPoint(Bitmap, Width, Height, Mask, BoxPoint);
+		TestTrue(
+			FString::Printf(TEXT("ConvertBitmapToBoxPoint succeeds for mask %d"), Mask),
+			FCameraSensorUtils::ConvertBitmapToBoxPoint(Bitmap, Width, Height, Mask, BoxPoint));
 
 		int32 ExpectedChannels = 0;
 		if (Mask & static_cast<uint8>(EChannels::R)) { ++ExpectedChannels; }
@@ -639,12 +643,14 @@ bool FCameraSensorUtils_ConvertBitmap_Normalization_Test::RunTest(const FString&
 	TArray<FColor> Bitmap = { FColor(0, 127, 255, 255) };
 
 	FBoxPoint BoxPoint;
-	FCameraSensorUtils::ConvertBitmapToBoxPoint(
-		Bitmap,
-		1,
-		1,
-		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B),
-		BoxPoint);
+	TestTrue(
+		TEXT("ConvertBitmapToBoxPoint succeeds"),
+		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+			Bitmap,
+			1,
+			1,
+			static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G) | static_cast<uint8>(EChannels::B),
+			BoxPoint));
 
 	TestEqual(TEXT("Zero normalizes to 0"), BoxPoint.Values[0], 0.0f);
 	TestEqual(TEXT("127 normalizes correctly"), BoxPoint.Values[1], 127.0f / 255.0f);
@@ -658,17 +664,25 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 bool FCameraSensorUtils_ConvertBitmap_SizeMismatch_Test::RunTest(const FString& Parameters)
 {
+	AddExpectedError(
+		TEXT("Bitmap size"),
+		EAutomationExpectedErrorFlags::Contains,
+		1);
+
 	TArray<FColor> Bitmap = { FColor(255, 0, 0, 255), FColor(0, 255, 0, 255) };
 
 	FBoxPoint BoxPoint;
-	FCameraSensorUtils::ConvertBitmapToBoxPoint(
-		Bitmap,
-		1,
-		1,
-		static_cast<uint8>(EChannels::R),
-		BoxPoint);
+	TestFalse(
+		TEXT("ConvertBitmapToBoxPoint fails on size mismatch"),
+		FCameraSensorUtils::ConvertBitmapToBoxPoint(
+			Bitmap,
+			1,
+			1,
+			static_cast<uint8>(EChannels::R),
+			BoxPoint));
 
 	TestEqual(TEXT("Mismatch leaves values unallocated"), BoxPoint.Values.Num(), 0);
+	TestEqual(TEXT("Mismatch leaves shape unallocated"), BoxPoint.Shape.Num(), 0);
 
 	return true;
 }

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -7,10 +7,11 @@
 
 #if WITH_DEV_AUTOMATION_TESTS
 
-// Helper function to create a CameraSensor with a TextureRenderTarget2D
+// These tests exercise channel/observation-space logic only (no pixel readback or scene capture).
+// Do not add EAutomationTestFlags::NonNullRHI unless a test reads GPU resources (e.g. CollectObservations).
 static UCameraSensor* CreateCameraSensorWithRenderTarget(
-	int32 Width, 
-	int32 Height, 
+	int32 Width,
+	int32 Height,
 	ETextureRenderTargetFormat Format,
 	ESceneCaptureSource CaptureSource,
 	uint8 EnabledChannels)
@@ -18,12 +19,14 @@ static UCameraSensor* CreateCameraSensorWithRenderTarget(
 	UCameraSensor* Sensor = NewObject<UCameraSensor>();
 	UTextureRenderTarget2D* RenderTarget = NewObject<UTextureRenderTarget2D>();
 	RenderTarget->RenderTargetFormat = Format;
-	RenderTarget->InitAutoFormat(Width, Height);
-	
+	// Set dimensions directly; InitAutoFormat would allocate RHI resources unnecessarily here.
+	RenderTarget->SizeX = Width;
+	RenderTarget->SizeY = Height;
+
 	Sensor->TextureTarget = RenderTarget;
 	Sensor->CaptureSource = CaptureSource;
 	Sensor->EnabledChannels = EnabledChannels;
-	
+
 	return Sensor;
 }
 

--- a/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
+++ b/Source/ScholaInteractors/Private/Test/Sensors/CameraSensorTest.cpp
@@ -2,6 +2,7 @@
 
 #include "Misc/AutomationTest.h"
 #include "Sensors/CameraSensor.h"
+#include "Sensors/CameraSensorUtils.h"
 #include "Engine/TextureRenderTarget2D.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
@@ -368,7 +369,7 @@ bool FCameraSensorObservationSpace_128x128_RGB_Test::RunTest(const FString& Para
 	
 	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
 	
-	// Shape should be [3, 128, 128] for CHW format (3 channels, height, width)
+	// Shape should be [3, 128, 128] for row-major CHW format (3 channels, height, width)
 	TestEqual(TEXT("Shape should have 3 dimensions"), Space.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 3 (channels)"), Space.Shape[0], 3);
 	TestEqual(TEXT("Shape[1] should be 128 (height)"), Space.Shape[1], 128);
@@ -403,7 +404,7 @@ bool FCameraSensorObservationSpace_256x256_RGBA_Test::RunTest(const FString& Par
 	
 	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
 	
-	// Shape should be [4, 256, 256] for CHW format
+	// Shape should be [4, 256, 256] for row-major CHW format
 	TestEqual(TEXT("Shape should have 3 dimensions"), Space.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 4 (channels)"), Space.Shape[0], 4);
 	TestEqual(TEXT("Shape[1] should be 256 (height)"), Space.Shape[1], 256);
@@ -431,7 +432,7 @@ bool FCameraSensorObservationSpace_64x64_R_Only_Test::RunTest(const FString& Par
 	
 	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
 	
-	// Shape should be [1, 64, 64] for CHW format (1 channel)
+	// Shape should be [1, 64, 64] for row-major CHW format (1 channel)
 	TestEqual(TEXT("Shape should have 3 dimensions"), Space.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 1 (channel)"), Space.Shape[0], 1);
 	TestEqual(TEXT("Shape[1] should be 64 (height)"), Space.Shape[1], 64);
@@ -459,7 +460,7 @@ bool FCameraSensorObservationSpace_512x512_RG_Test::RunTest(const FString& Param
 	
 	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
 	
-	// Shape should be [2, 512, 512] for CHW format (2 channels)
+	// Shape should be [2, 512, 512] for row-major CHW format (2 channels)
 	TestEqual(TEXT("Shape should have 3 dimensions"), Space.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 2 (channels)"), Space.Shape[0], 2);
 	TestEqual(TEXT("Shape[1] should be 512 (height)"), Space.Shape[1], 512);
@@ -487,7 +488,7 @@ bool FCameraSensorObservationSpace_NonSquare_Test::RunTest(const FString& Parame
 	
 	const FBoxSpace& Space = ObservationSpace.Get<FBoxSpace>();
 	
-	// Shape should be [3, 240, 320] for CHW format
+	// Shape should be [3, 240, 320] for row-major CHW format
 	TestEqual(TEXT("Shape should have 3 dimensions"), Space.Shape.Num(), 3);
 	TestEqual(TEXT("Shape[0] should be 3 (channels)"), Space.Shape[0], 3);
 	TestEqual(TEXT("Shape[1] should be 240 (height)"), Space.Shape[1], 240);
@@ -496,6 +497,73 @@ bool FCameraSensorObservationSpace_NonSquare_Test::RunTest(const FString& Parame
 	// Total dimensions should be 3 * 240 * 320 = 230400
 	TestEqual(TEXT("Total dimensions should be 230400"), Space.Dimensions.Num(), 230400);
 	
+	return true;
+}
+
+// Verify bitmap conversion preserves width/height orientation (no transpose)
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCameraSensorUtils_ConvertBitmap_NoTranspose_Test,
+	"Schola.Sensors.CameraSensorUtils.ConvertBitmap.NoTranspose",
+	EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FCameraSensorUtils_ConvertBitmap_NoTranspose_Test::RunTest(const FString& Parameters)
+{
+	constexpr int32 Width = 4;
+	constexpr int32 Height = 3;
+	const int32 ChannelStride = Width * Height;
+
+	TArray<FColor> Bitmap;
+	Bitmap.SetNum(ChannelStride);
+
+	for (int32 H = 0; H < Height; ++H)
+	{
+		for (int32 W = 0; W < Width; ++W)
+		{
+			const int32 PixelIndex = H * Width + W;
+			// R encodes (w, h); G encodes transposed (h, w) so a width/height swap is detectable.
+			Bitmap[PixelIndex] = FColor(
+				static_cast<uint8>(W * Height + H),
+				static_cast<uint8>(H * Width + W),
+				0,
+				255);
+		}
+	}
+
+	FBoxPoint BoxPoint;
+	FCameraSensorUtils::ConvertBitmapToBoxPoint(
+		Bitmap,
+		Width,
+		Height,
+		static_cast<uint8>(EChannels::R) | static_cast<uint8>(EChannels::G),
+		BoxPoint);
+
+	TestEqual(TEXT("Shape should have 3 dimensions"), BoxPoint.Shape.Num(), 3);
+	TestEqual(TEXT("Shape[0] should be 2 (channels)"), BoxPoint.Shape[0], 2);
+	TestEqual(TEXT("Shape[1] should be height"), BoxPoint.Shape[1], Height);
+	TestEqual(TEXT("Shape[2] should be width"), BoxPoint.Shape[2], Width);
+	TestEqual(TEXT("Values length should match channels * height * width"), BoxPoint.Values.Num(), ChannelStride * 2);
+
+	for (int32 H = 0; H < Height; ++H)
+	{
+		for (int32 W = 0; W < Width; ++W)
+		{
+			const int32 PixelIndex = H * Width + W;
+			const float ExpectedR = static_cast<float>(W * Height + H) / 255.0f;
+			const float ExpectedG = static_cast<float>(H * Width + W) / 255.0f;
+
+			TestEqual(
+				FString::Printf(TEXT("R channel at (%d, %d) should not be transposed"), W, H),
+				BoxPoint.Values[0 * ChannelStride + PixelIndex],
+				ExpectedR);
+
+			TestEqual(
+				FString::Printf(TEXT("G channel at (%d, %d) should not be transposed"), W, H),
+				BoxPoint.Values[1 * ChannelStride + PixelIndex],
+				ExpectedG);
+		}
+	}
+
 	return true;
 }
 

--- a/Source/ScholaInteractors/Public/Sensors/CameraSensor.h
+++ b/Source/ScholaInteractors/Public/Sensors/CameraSensor.h
@@ -102,7 +102,7 @@ public:
 	 * @brief Collect image observations from the render target.
 	 * 
 	 * Reads pixels from the render target, extracts enabled channels, and normalizes to [0,1].
-	 * The resulting BoxPoint has shape [NumChannels, Width, Height] in CHW (channel-first) format.
+	 * The resulting BoxPoint has shape [NumChannels, Height, Width] in row-major (CHW) layout.
 	 * 
 	 * @param[out] OutObservations A BoxPoint that will be populated with normalized pixel values
 	 */
@@ -113,7 +113,7 @@ public:
 	 * 
 	 * Returns a BoxSpace describing the image dimensions and channels.
 	 * Each dimension is bounded [0.0, 1.0] for normalized pixel values.
-	 * Shape is [NumChannels, Height, Width] in CHW format.
+	 * Shape is [NumChannels, Height, Width] in row-major (CHW) layout.
 	 * 
 	 * @param[out] OutObservationSpace The observation space definition to be populated
 	 */

--- a/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
+++ b/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Points/BoxPoint.h"
+
+class UTextureRenderTarget2D;
+
+/**
+ * @brief Utilities for converting camera render targets into Schola box points.
+ */
+struct SCHOLAINTERACTORS_API FCameraSensorUtils
+{
+	/**
+	 * @brief Converts a row-major FColor bitmap into a normalized FBoxPoint.
+	 *
+	 * Output shape is [NumChannels, Height, Width] in row-major (CHW) layout.
+	 * Each channel plane matches the row-major ReadPixels bitmap order:
+	 * index = c * H * W + h * W + w.
+	 *
+	 * @param[in] Bitmap Row-major pixel data with length Width * Height.
+	 * @param[in] Width Texture width in pixels.
+	 * @param[in] Height Texture height in pixels.
+	 * @param[in] EnabledValidChannels Bitmask of RGBA channels to include (already filtered).
+	 * @param[out] OutBoxPoint Populated box point.
+	 */
+	static void ConvertBitmapToBoxPoint(
+		const TArray<FColor>& Bitmap,
+		int32 Width,
+		int32 Height,
+		uint8 EnabledValidChannels,
+		FBoxPoint& OutBoxPoint);
+
+	/**
+	 * @brief Reads pixels from a render target into a normalized FBoxPoint.
+	 *
+	 * @param[in] TextureTarget Render target to read from.
+	 * @param[in] EnabledValidChannels Bitmask of RGBA channels to include (already filtered).
+	 * @param[out] OutBoxPoint Populated box point.
+	 * @return True if pixels were read and converted successfully.
+	 */
+	static bool ReadRenderTargetToBoxPoint(
+		UTextureRenderTarget2D* TextureTarget,
+		uint8 EnabledValidChannels,
+		FBoxPoint& OutBoxPoint);
+};

--- a/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
+++ b/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
@@ -10,7 +10,7 @@ class UTextureRenderTarget2D;
 /**
  * @brief Utilities for converting camera render targets into Schola box points.
  */
-struct SCHOLAINTERACTORS_API FCameraSensorUtils
+namespace FCameraSensorUtils
 {
 	/**
 	 * @brief Converts a row-major FColor bitmap into a normalized FBoxPoint.
@@ -26,7 +26,7 @@ struct SCHOLAINTERACTORS_API FCameraSensorUtils
 	 * @param[out] OutBoxPoint Populated box point; left unchanged when Bitmap size does not match Width * Height.
 	 * @return True if the bitmap was converted successfully.
 	 */
-	static bool ConvertBitmapToBoxPoint(
+	SCHOLAINTERACTORS_API bool ConvertBitmapToBoxPoint(
 		const TArray<FColor>& Bitmap,
 		int32 Width,
 		int32 Height,
@@ -41,8 +41,8 @@ struct SCHOLAINTERACTORS_API FCameraSensorUtils
 	 * @param[out] OutBoxPoint Populated box point.
 	 * @return True if pixels were read and converted successfully.
 	 */
-	static bool ReadRenderTargetToBoxPoint(
+	SCHOLAINTERACTORS_API bool ReadRenderTargetToBoxPoint(
 		UTextureRenderTarget2D* TextureTarget,
 		uint8 EnabledValidChannels,
 		FBoxPoint& OutBoxPoint);
-};
+}

--- a/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
+++ b/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
@@ -10,7 +10,7 @@ class UTextureRenderTarget2D;
 /**
  * @brief Utilities for converting camera render targets into Schola box points.
  */
-namespace FCameraSensorUtils
+namespace CameraSensorUtils
 {
 	/**
 	 * @brief Converts a row-major FColor bitmap into a normalized FBoxPoint.

--- a/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
+++ b/Source/ScholaInteractors/Public/Sensors/CameraSensorUtils.h
@@ -23,9 +23,10 @@ struct SCHOLAINTERACTORS_API FCameraSensorUtils
 	 * @param[in] Width Texture width in pixels.
 	 * @param[in] Height Texture height in pixels.
 	 * @param[in] EnabledValidChannels Bitmask of RGBA channels to include (already filtered).
-	 * @param[out] OutBoxPoint Populated box point.
+	 * @param[out] OutBoxPoint Populated box point; left unchanged when Bitmap size does not match Width * Height.
+	 * @return True if the bitmap was converted successfully.
 	 */
-	static void ConvertBitmapToBoxPoint(
+	static bool ConvertBitmapToBoxPoint(
 		const TArray<FColor>& Bitmap,
 		int32 Width,
 		int32 Height,

--- a/Source/conftest.py
+++ b/Source/conftest.py
@@ -148,6 +148,15 @@ def get_unreal_timeout_from_config(config) -> int:
         return int(timeout_option)
     return int(config.getini("unreal_timeout"))
 
+def get_null_rhi_from_config(config) -> bool:
+    # --no-null-rhi takes precedence
+    if config.getoption("--no-null-rhi"):
+        return False
+    null_rhi_option = config.getoption("--null-rhi")
+    if null_rhi_option is not None:
+        return null_rhi_option
+    return config.getini("null_rhi")
+
 def pytest_addoption(parser):
     try:
         parser.addoption(
@@ -259,6 +268,50 @@ def pytest_addoption(parser):
     except ValueError:
         pass
 
+    try:
+        parser.addoption(
+            "--null-rhi",
+            action="store_true",
+            default=None,
+            help="Run Unreal automation tests with NullRHI (default unless null_rhi ini is false)",
+        )
+    except ValueError:
+        pass
+
+    try:
+        parser.addoption(
+            "--no-null-rhi",
+            action="store_true",
+            default=False,
+            help="Run Unreal with a real RHI (required for NonNullRHI automation tests)",
+        )
+    except ValueError:
+        pass
+
+    try:
+        parser.addini(
+            "null_rhi",
+            type="bool",
+            help="Run Unreal automation tests with NullRHI",
+            default=True,
+        )
+    except ValueError:
+        pass
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "non_null_rhi: Unreal automation test that requires a real RHI (pass --no-null-rhi)",
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if not get_null_rhi_from_config(config):
+        return
+    skip_marker = pytest.mark.skip(reason="Requires real RHI (pass --no-null-rhi)")
+    for item in items:
+        if isinstance(item, UnrealTestItem) and "requires_rhi" in item.flags:
+            item.add_marker(skip_marker)
+
 @pytest.fixture(scope="session")
 def unreal_path(request) -> pathlib.Path:
     return get_engine_path_from_config(request.config)
@@ -334,6 +387,7 @@ class UnrealTestRunner:
         self.unreal_path = get_engine_path_from_config(session.config)
         self.should_build = get_build_unreal_from_config(session.config)
         self.generate_cpp_coverage_report = is_cpp_coverage_enabled(session.config)
+        self.use_null_rhi = get_null_rhi_from_config(session.config)
         self.report_dir = report_dir
         self.command_line_file_dir = command_line_file_dir
 
@@ -354,7 +408,9 @@ class UnrealTestRunner:
                 "Error Building Unreal Project: No .uproject file found in directory"
             )
             unreal_test_batches = [
-                UnrealTestBatch(batch, self.report_dir, i, self.command_line_file_dir)
+                UnrealTestBatch(
+                    batch, self.report_dir, i, self.command_line_file_dir, use_null_rhi=self.use_null_rhi
+                )
                 for i, batch in enumerate(batches_list)
             ]
             for test_batch in unreal_test_batches:
@@ -389,13 +445,20 @@ class UnrealTestRunner:
         if opencpp is not None:
             unreal_test_batches = [
                 UnrealCoverageTestBatch(
-                    batch, self.report_dir, i, self.command_line_file_dir, opencpp=opencpp
+                    batch,
+                    self.report_dir,
+                    i,
+                    self.command_line_file_dir,
+                    use_null_rhi=self.use_null_rhi,
+                    opencpp=opencpp,
                 )
                 for i, batch in enumerate(batches_list)
             ]
         else:
             unreal_test_batches = [
-                UnrealTestBatch(batch, self.report_dir, i, self.command_line_file_dir)
+                UnrealTestBatch(
+                    batch, self.report_dir, i, self.command_line_file_dir, use_null_rhi=self.use_null_rhi
+                )
                 for i, batch in enumerate(batches_list)
             ]
 
@@ -500,7 +563,11 @@ def pytest_runtestloop(session):
     if session.config.option.collectonly:
         return True
 
-    unreal_items = [item for item in session.items if isinstance(item, UnrealTestItem)]
+    unreal_items = [
+        item
+        for item in session.items
+        if isinstance(item, UnrealTestItem) and not item.get_closest_marker("skip")
+    ]
 
     # Run Unreal tests in batch if we have any (only on Windows, since linux can hang)
     if unreal_items and sys.platform == "win32":

--- a/Source/unreal_test_classes.py
+++ b/Source/unreal_test_classes.py
@@ -25,10 +25,14 @@ import re
 # Match IMPLEMENT_SIMPLE_AUTOMATION_TEST(...); `\s` spans newlines so split arguments are found.
 # matches One Word Struct Name, Test Name in quotes, and then arbitrary flags and closing parenthesis
 # , and ) need to be on the same line as the preceding content and no space between them
-AUTOMATION_TEST_PATTERN = r'^IMPLEMENT_SIMPLE_AUTOMATION_TEST\(\s*[^,\s]+,\s*"([^"]+)",\s*[^,]+\)'
+AUTOMATION_TEST_PATTERN = r'^IMPLEMENT_SIMPLE_AUTOMATION_TEST\(\s*[^,\s]+,\s*"([^"]+)",\s*([^)]+)\)'
+
+FLAGS = {
+    "requires_rhi": "NonNullRHI",
+}
 
 def iter_automation_test_paths_with_lines(source: str):
-    """Yield (test_path, lineno) for each automation test macro in C++ source.
+    """Yield (test_path, lineno, flags) for each automation test macro.
 
     lineno is 0-based (consistent with enumerate over readlines) and points to the
     line where the macro invocation starts.
@@ -38,25 +42,41 @@ def iter_automation_test_paths_with_lines(source: str):
     lineno = 0
     for match in pattern.finditer(source):
         lineno += source.count("\n", prev_start, match.start())
-        yield match.group(1), lineno
+        flags_str = match.group(2)
+        flags = set(x for x,y in FLAGS.items() if y in flags_str)
+        yield match.group(1), lineno, flags
         prev_start = match.start()
 
 logger = logging.getLogger(__name__)
 
 class UnrealTestItem(pytest.Item):
 
-    def __init__(self, name:str, test_path:str, cpp_file:pathlib.Path, line_number:int=0, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        test_path: str,
+        cpp_file: pathlib.Path,
+        line_number: int = 0,
+        flags: set[str] = set(),
+        **kwargs,
+    ):
         name = name.strip()
-        super().__init__(name=name,**kwargs)
-        self.unreal_result : Optional[UnrealTestResult] = None  # Will be populated by pytest_runtestloop
+        super().__init__(name=name, **kwargs)
+        self.unreal_result: Optional[UnrealTestResult] = None  # Will be populated by pytest_runtestloop
         self.cpp_file = cpp_file
-        self.lineno = line_number 
+        self.lineno = line_number
         self.test_path = test_path
+        self.flags = flags
         try:
             self.add_marker(pytest.mark.xdist_group("unreal_automation_tests"))
-        except:
+        except Exception:
             # wasn't able to mark, probably because pytest-xdist isn't installed which is OK
             pass
+        if "requires_rhi" in flags:
+            try:
+                self.add_marker(pytest.mark.non_null_rhi)
+            except Exception:
+                pass
 
     @property
     def sanitized_test_path(self) -> str:
@@ -122,9 +142,16 @@ class UnrealTestFile(pytest.File):
             source = f.read()
         test_details = list(iter_automation_test_paths_with_lines(source))
 
-        for test_path, line_number in test_details:
-            name = test_path.split(".")[-1] # Use the last part of the full path
-            yield UnrealTestItem.from_parent(self, name=name, test_path=test_path, cpp_file=self.path, line_number=line_number)
+        for test_path, line_number, flags in test_details:
+            name = test_path.split(".")[-1]  # Use the last part of the full path
+            yield UnrealTestItem.from_parent(
+                self,
+                name=name,
+                test_path=test_path,
+                cpp_file=self.path,
+                line_number=line_number,
+                flags=flags,
+            )
 
 # Use this to have custom exceptions
 class UnrealTestException(Exception):
@@ -231,6 +258,7 @@ class UnrealTestBatch:
     report_dir: pathlib.Path
     batch_index: int
     command_line_args_folder: pathlib.Path
+    use_null_rhi: bool = True
     _process: Optional[subprocess.Popen] = None
     retries: int = 0
 
@@ -258,15 +286,15 @@ class UnrealTestBatch:
 
     @property
     def command_line_arg_string(self) -> str:
-        return " ".join(
-            [
-                "-unattended",
-                "-nullrhi",
-                "-NoTrace",
-                f'-ReportExportPath="{self.report_path}"',
-                f'-ExecCmds="Automation RunTest {self.test_string};Quit"',
-            ]
-        )
+        args = [
+            "-unattended",
+            "-NoTrace",
+            f'-ReportExportPath="{self.report_path}"',
+            f'-ExecCmds="Automation RunTest {self.test_string};Quit"',
+        ]
+        if self.use_null_rhi:
+            args.insert(1, "-nullrhi")
+        return " ".join(args)
 
     def write_command_line_args_file(self) -> None:
         with open(self.command_line_args_file, "w") as f:

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,6 +30,7 @@ testpaths =
     Source
 engine_path = C:/Program Files/Epic Games/UE_5.7
 build_unreal = True
+null_rhi = False
 schola_cpp_coverage_html = False
 schola_cpp_coverage_cobertura = False
 log_file = pytest.log

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,7 +30,7 @@ testpaths =
     Source
 engine_path = C:/Program Files/Epic Games/UE_5.7
 build_unreal = True
-null_rhi = False
+null_rhi = True
 schola_cpp_coverage_html = False
 schola_cpp_coverage_cobertura = False
 log_file = pytest.log


### PR DESCRIPTION
## Summary

Add support for controlling render mode through pytest, add additional tests for camera sensors to more thoroughly validate that camera sensors are working properly.


## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Refactor or internal cleanup

## Changes

- New tests for camera sensors
- Fix of an issue with Camera Dimensions not aligning between Observation Spaces and Observation collection
- New Config option for toggling rendering when running Unreal Pytests
- Add support for skipping tests that require rendering when rendering is disabled


## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)

- [x] Built / recompiled the project after Unreal Engine changes
- [x] Ran relevant automation tests (editor or pytest on Windows; see CONTRIBUTING.md)

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files
