### PR TITLE
fix(python): skip action lookup on NEXT_STEP gym autoreset

### DIFF
--- a/Resources/python/schola/core/simulators/gym/servicer.py
+++ b/Resources/python/schola/core/simulators/gym/servicer.py
@@ -130,7 +130,18 @@ class GymToGymServiceServicer(GymServiceServicer):
             return response
 
         elif msg_type == "step":
-            action = from_proto(request.step.environments[0].updates[self._agent_id])
+            updates = request.step.environments[0].updates
+
+            def next_action():
+                # Under NEXT_STEP autoreset the client sends no action for an
+                # environment that is being reset, so only read the map on the
+                # branches that actually step. Indexing a protobuf map inserts a
+                # default entry, hence the explicit membership check.
+                if self._agent_id not in updates:
+                    raise ValueError(
+                        f"Step update contains no action for agent '{self._agent_id}'."
+                    )
+                return from_proto(updates[self._agent_id])
 
             initial_state: InitialState | None = None
 
@@ -140,17 +151,20 @@ class GymToGymServiceServicer(GymServiceServicer):
                     reward = 0.0
                     terminated = False
                     truncated = False
+                    self._completed_env = False
                 else:
-                    obs, reward, terminated, truncated, info = self.env.step(action)
+                    obs, reward, terminated, truncated, info = self.env.step(
+                        next_action()
+                    )
                     self._completed_env = terminated or truncated
             elif self._autoreset_type == AutoResetType.DISABLED:
                 assert (
                     not self._completed_env
                 ), "Attempted to step an environment that is already terminated or truncated"
-                obs, reward, terminated, truncated, info = self.env.step(action)
+                obs, reward, terminated, truncated, info = self.env.step(next_action())
                 self._completed_env = terminated or truncated
             elif self._autoreset_type == AutoResetType.SAME_STEP:
-                obs, reward, terminated, truncated, info = self.env.step(action)
+                obs, reward, terminated, truncated, info = self.env.step(next_action())
                 if terminated or truncated:
                     initial_obs, initial_info = self.env.reset()
                     initial_state = self._make_initial_state(initial_obs, initial_info)

--- a/Test/core/test_gym_service.py
+++ b/Test/core/test_gym_service.py
@@ -62,6 +62,13 @@ def _step(servicer: GymToGymServiceServicer, action: int):
     return servicer.UpdateState(state_update, None)
 
 
+def _step_without_action(servicer: GymToGymServiceServicer):
+    """Send a step update whose ``updates`` map is empty, as RLlib does on an autoreset step."""
+    state_update = StateUpdate(step=Step())
+    state_update.step.environments.add()
+    return servicer.UpdateState(state_update, None)
+
+
 def _agent_state_values(state):
     agent = state.training_state.environment_states[0].agent_states["single_agent"]
     obs, reward, terminated, truncated, _info = from_proto(agent)
@@ -133,6 +140,35 @@ class TestAutoreset:
             assert obs == 1
             assert reward == 1.0
             assert terminated is False
+
+    def test_next_step_autoreset_without_action(self):
+        """RLlib sends no action for an env being autoreset, so the servicer must not read one."""
+        servicer = GymToGymServiceServicer(_make_env_factory(max_count=2))
+        _start_servicer(servicer, AutoResetType.NEXT_STEP)
+        _reset(servicer)
+
+        _step(servicer, 1)
+        _step(servicer, 1)
+
+        state = _step_without_action(servicer)
+        obs, reward, terminated, _truncated = _agent_state_values(state)
+        assert obs == 0
+        assert reward == 0.0
+        assert terminated is False
+
+        # The new episode must run normally rather than resetting on every step.
+        state = _step(servicer, 1)
+        obs, _reward, terminated, _truncated = _agent_state_values(state)
+        assert obs == 1
+        assert terminated is False
+
+    def test_step_without_action_raises_when_action_required(self):
+        servicer = GymToGymServiceServicer(_make_env_factory(max_count=2))
+        _start_servicer(servicer, AutoResetType.NEXT_STEP)
+        _reset(servicer)
+
+        with pytest.raises(Exception, match="no action for agent"):
+            _step_without_action(servicer)
 
     def test_autoreset_disabled_blocks_step_after_done(self):
         servicer = GymToGymServiceServicer(_make_env_factory(max_count=1))


### PR DESCRIPTION


## Summary

RLlib omits the action for an env being reset, and protobuf map indexing was inserting a default entry and leaving completed_env set.

## Related issues

<!-- Link issues this addresses, e.g. Fixes #123 or Relates to #456. -->

## Type of change

- [x] Bug fix

## Changes

- Adjusted the Gym Service Servicer

## Testing

<!-- How did you verify this works? Delete sections that do not apply. -->

### Python (`Resources/python`, `Test`)

- [x] Installed test dependencies: `pip install --group test -e "./Resources/python[all]"`
- [x] Ran: `python -m pytest Test --import-mode=importlib -n 0`

### Unreal C++ (`Source`)
- [x] Not applicable

## Checklist

- [x] Code follows project style (Unreal coding standard for C++; [Black](https://black.readthedocs.io/) for Python)
- [x] Comments / docstrings added or updated where behavior is non-obvious
- [x] README or Sphinx docs updated if user-facing behavior changed
- [x] No unrelated changes included in this PR
- [x] Appropriate license headers added to new files